### PR TITLE
add additional components/items to the top menu bar skeleton 

### DIFF
--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -1,0 +1,26 @@
+import { Button, Menu } from '@mantine/core';
+
+export function HelpMenu() {
+  return (
+    <Menu position={'bottom-start'} offset={4} withArrow arrowPosition={'center'}>
+      <Menu.Target>
+        <Button size={'xs'} color={'gray'}>
+          Help
+        </Button>
+      </Menu.Target>
+      <Menu.Dropdown>
+        <Menu.Item>Open Web Tutorials</Menu.Item>
+        <Menu.Item>Open Getting Started Tour</Menu.Item>
+        <Menu.Divider />
+        <Menu.Item>Send Feedback</Menu.Item>
+        <Menu.Divider />
+        <Menu.Item>Toggle Console</Menu.Item>
+        <Menu.Item>Open GUI in Browser</Menu.Item>
+        <Menu.Divider />
+        <Menu.Item>Quit OpenSpace</Menu.Item>
+        <Menu.Divider />
+        <Menu.Item>About</Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+}

--- a/src/components/TopMenuBar.tsx
+++ b/src/components/TopMenuBar.tsx
@@ -4,6 +4,7 @@ import { Button, Group, Menu } from '@mantine/core';
 import { TaskBarMenuChoices } from './TaskBarMenuChoices';
 import { NewWindowMenu } from './NewWindowMenu';
 import { WindowLayoutOptions } from './WindowLayout';
+import { HelpMenu } from './HelpMenu';
 
 interface TopMenuBarProps {
   visibleMenuItems: string[];
@@ -27,6 +28,7 @@ export function TopMenuBar({
       <Button size={'xs'} color="gray">
         Asset
       </Button>
+
       <Menu position={'bottom-start'} offset={4} withArrow arrowPosition={'center'}>
         <Menu.Target>
           <Button size={'xs'} color="gray">
@@ -34,8 +36,6 @@ export function TopMenuBar({
           </Button>
         </Menu.Target>
         <Menu.Dropdown>
-          <Menu.Item>Kebab menu</Menu.Item>
-          <Menu.Divider />
           <Menu.Item>Settings</Menu.Item>
         </Menu.Dropdown>
       </Menu>
@@ -55,6 +55,8 @@ export function TopMenuBar({
           <Menu.Item>Load/Save Layout</Menu.Item>
         </Menu.Dropdown>
       </Menu>
+
+      <HelpMenu />
     </Group>
   );
 }

--- a/src/util/MenuItems.tsx
+++ b/src/util/MenuItems.tsx
@@ -27,10 +27,59 @@ export const menuItemsDB: MenuItem[] = [
     defaultVisible: true
   },
   {
+    title: 'Date Picker',
+    componentID: 'datePicker',
+    content: <div>Date / Time Menu</div>,
+    preferredPosition: 'float',
+    defaultVisible: true
+  },
+  {
     title: 'Session Recording',
     componentID: 'sessionRecording',
     content: <SessionRec />,
     preferredPosition: 'right',
+    defaultVisible: true
+  },
+  {
+    title: 'Geo Location',
+    componentID: 'geoLocation',
+    content: <div>Geo Location menu</div>,
+    preferredPosition: 'left',
+    defaultVisible: true
+  },
+  {
+    title: 'Exoplanets',
+    componentID: 'exoplanets',
+    content: <div> Exoplanets menu </div>,
+    preferredPosition: 'right',
+    defaultVisible: false
+  },
+  {
+    title: 'User Control',
+    componentID: 'userControl',
+    content: <div>User control menu</div>,
+    preferredPosition: 'right',
+    defaultVisible: false
+  },
+  {
+    title: 'Actions',
+    componentID: 'actions',
+    content: <div>Actions menu</div>,
+    preferredPosition: 'float',
+    defaultVisible: true
+  },
+  {
+    title: 'Sky Browser',
+    componentID: 'skyBrowser',
+    content: <div>Sky Broweser</div>,
+    preferredPosition: 'right',
+    defaultVisible: false
+  },
+  {
+    title: 'Keybindings Layout',
+    componentID: 'keybindingsLayout',
+    content: <div>Keybindings</div>,
+    preferredPosition: 'float',
     defaultVisible: false
   }
 ];


### PR DESCRIPTION
The `HelpMenu` replaces the old kebab with useful links in bottom left corner