### PR TITLE
Fix broken add property function

### DIFF
--- a/src/redux/propertytree/properties/propertiesSlice.ts
+++ b/src/redux/propertytree/properties/propertiesSlice.ts
@@ -2,8 +2,6 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { Properties, PropertyValue, Uri } from '@/types/types';
 
-import { addUriToPropertyTree } from '../propertyTreeMiddleware';
-
 export interface PropertiesState {
   isInitialized: boolean;
   properties: Properties;
@@ -28,8 +26,10 @@ export const propertiesSlice = createSlice({
   name: 'properties',
   initialState,
   reducers: {
-    addProperties: (state, action: PayloadAction<{ properties: Properties }>) => {
-      state.properties = { ...state.properties, ...action.payload.properties };
+    addProperties: (state, action: PayloadAction<Properties>) => {
+      for (const [uri, property] of Object.entries(action.payload)) {
+        state.properties[uri] = property;
+      }
       return state;
     },
     removeProperties: (state, action: PayloadAction<{ uris: string[] }>) => {
@@ -75,14 +75,6 @@ export const propertiesSlice = createSlice({
       //   [action.payload.uri]: newPropertyState
       // };
     }
-  },
-  extraReducers: (builder) => {
-    builder.addCase(addUriToPropertyTree.fulfilled, (state, action) => {
-      if (action.payload?.properties) {
-        state.properties = { ...state.properties, ...action.payload.properties };
-      }
-      return state;
-    });
   }
 });
 

--- a/src/redux/propertytree/propertyTreeMiddleware.ts
+++ b/src/redux/propertytree/propertyTreeMiddleware.ts
@@ -18,6 +18,7 @@ import { refreshGroups } from '../groups/groupsSliceMiddleware';
 
 import { clearProperties, removeProperties } from './properties/propertiesSlice';
 import {
+  addPropertyOwners,
   clearPropertyOwners,
   removePropertyOwners
 } from './propertyowner/propertyOwnerSlice';
@@ -33,7 +34,6 @@ export const addUriToPropertyTree = createAsyncThunk(
     const response = (await api.getProperty(uri)) as
       | OpenSpaceProperty
       | OpenSpacePropertyOwner;
-
     if ('properties' in response) {
       const { properties, propertyOwners } = flattenPropertyTree(response);
       const propertiesMap: Properties = {};
@@ -149,6 +149,15 @@ export const addPropertyTreeListener = (startListening: AppStartListening) => {
       // TODO anden88 2024-10-18: Right now the reloadPropertyTree is only dispatched here
       // consder to put the reload logic in here immedieately?
       listenerApi.dispatch(reloadPropertyTree());
+    }
+  });
+
+  startListening({
+    actionCreator: addUriToPropertyTree.fulfilled,
+    effect: (action, listenerApi) => {
+      if (action.payload?.propertyOwners) {
+        listenerApi.dispatch(addPropertyOwners(action.payload.propertyOwners));
+      }
     }
   });
 

--- a/src/redux/propertytree/propertyTreeMiddleware.ts
+++ b/src/redux/propertytree/propertyTreeMiddleware.ts
@@ -16,7 +16,11 @@ import { rootOwnerKey } from '@/util/keys';
 
 import { refreshGroups } from '../groups/groupsSliceMiddleware';
 
-import { clearProperties, removeProperties } from './properties/propertiesSlice';
+import {
+  addProperties,
+  clearProperties,
+  removeProperties
+} from './properties/propertiesSlice';
 import {
   addPropertyOwners,
   clearPropertyOwners,
@@ -157,6 +161,9 @@ export const addPropertyTreeListener = (startListening: AppStartListening) => {
     effect: (action, listenerApi) => {
       if (action.payload?.propertyOwners) {
         listenerApi.dispatch(addPropertyOwners(action.payload.propertyOwners));
+      }
+      if (action.payload?.properties) {
+        listenerApi.dispatch(addProperties(action.payload.properties));
       }
     }
   });

--- a/src/redux/propertytree/propertyowner/propertyOwnerSlice.ts
+++ b/src/redux/propertytree/propertyowner/propertyOwnerSlice.ts
@@ -1,8 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { PropertyOwner, PropertyOwners, Uri } from '@/types/types';
-
-import { addUriToPropertyTree } from '../propertyTreeMiddleware';
+import { PropertyOwners, Uri } from '@/types/types';
 
 // actions:
 // addPropertyOwners
@@ -25,22 +23,12 @@ export const propertyOwnersSlice = createSlice({
   name: 'propertyOwners',
   initialState: initialStatePropertyOwners,
   reducers: {
-    addPropertyOwners: (
-      state,
-      action: PayloadAction<{ propertyOwners: PropertyOwner[] }>
-    ) => {
-      const inputOwners = action.payload.propertyOwners;
-      inputOwners.forEach((owner) => {
-        state.propertyOwners[owner.uri] = {
-          identifier: owner.identifier,
-          name: owner.name,
-          properties: owner.properties,
-          subowners: owner.subowners,
-          tags: owner.tags || [],
-          uri: owner.uri, // TODO: Remove this
-          description: owner.description
-        };
-
+    addPropertyOwners: (state, action: PayloadAction<PropertyOwners>) => {
+      for (const [uri, owner] of Object.entries(action.payload)) {
+        if (!owner) {
+          continue;
+        }
+        state.propertyOwners[uri] = owner;
         // Ensure the parents of the uri have the links to the new entry
         // Get parent uri
         const periodPos = owner.uri.lastIndexOf('.');
@@ -54,7 +42,8 @@ export const propertyOwnersSlice = createSlice({
         ) {
           state.propertyOwners[parentUri]!.subowners.push(owner.uri);
         }
-      });
+      }
+
       return state;
     },
     clearPropertyOwners: () => {
@@ -82,17 +71,6 @@ export const propertyOwnersSlice = createSlice({
       });
       return state;
     }
-  },
-  extraReducers: (builder) => {
-    builder.addCase(addUriToPropertyTree.fulfilled, (state, action) => {
-      if (action.payload?.propertyOwners) {
-        state.propertyOwners = {
-          ...state.propertyOwners,
-          ...action.payload.propertyOwners
-        };
-      }
-      return state;
-    });
   }
 });
 


### PR DESCRIPTION
The redux functions for adding propertyowners was not using the full linking (i.e. adding the subowners) so I added that. Now the adding of propertyowners in runtime should work again. Removing seems to work already but since this issue is related I'm adding issue 13
Closes #13 