### PR TITLE
Fix text wrapping

### DIFF
--- a/src/components/ThreePartHeader/ThreePartHeader.tsx
+++ b/src/components/ThreePartHeader/ThreePartHeader.tsx
@@ -1,4 +1,4 @@
-import { Group } from '@mantine/core';
+import { Group, Text } from '@mantine/core';
 
 interface Props {
   title: React.ReactNode;
@@ -8,12 +8,12 @@ interface Props {
 
 export function ThreePartHeader({ title, leftSection, rightSection }: Props) {
   return (
-    <Group justify={'space-between'} gap={'xs'} wrap={'nowrap'} w={'100%'}>
-      <Group gap={'xs'} flex={1} wrap={'nowrap'}>
-        {leftSection && leftSection}
+    <Group justify={'space-between'} gap={'xs'} w={'100%'}>
+      {leftSection}
+      <Text truncate flex={1}>
         {title}
-      </Group>
-      {rightSection && rightSection}
+      </Text>
+      {rightSection}
     </Group>
   );
 }

--- a/src/panels/GeoLocationPanel/AnchorPanels/EarthPanel/AddedCustomNodes.tsx
+++ b/src/panels/GeoLocationPanel/AnchorPanels/EarthPanel/AddedCustomNodes.tsx
@@ -1,0 +1,47 @@
+import { ActionIcon, Box, Text } from '@mantine/core';
+
+import { SceneGraphNodeHeader } from '@/panels/Scene/SceneGraphNode/SceneGraphNodeHeader';
+import { Identifier } from '@/types/types';
+import { sgnUri } from '@/util/propertyTreeHelpers';
+import { useWindowSize } from '@/windowmanagement/Window/hooks';
+import { MinusIcon } from '@/icons/icons';
+
+interface Props {
+  addedNodes: Identifier[];
+  removeFocusNode: (identifier: Identifier) => void;
+}
+
+// This component is its own to reduce the amount of rerenders in
+// EarthPanel due to the `useWindowSize()` hook
+export function AddedCustomNodes({ addedNodes, removeFocusNode }: Props) {
+  // TODO anden88 2025-02-07 Using the windowSize like this causes some stuttering when
+  // moving the window panel. Investigation with Ylva we found that the culprit is most
+  // likely the `ScrollArea` wrapping the entire window, possible solution is make own
+  // scroll behaviour and instead wrap in e.g, `Box`
+  const { width } = useWindowSize();
+  const containerPadding = 36;
+  const containerMaxWidth = 925;
+
+  return addedNodes.length === 0 ? (
+    <Text>No added nodes</Text>
+  ) : (
+    <Box w={width - containerPadding} maw={containerMaxWidth}>
+      {addedNodes.map((identifier) => (
+        <SceneGraphNodeHeader
+          key={identifier}
+          uri={sgnUri(identifier)}
+          leftSection={
+            <ActionIcon
+              variant={'light'}
+              size={'sm'}
+              color={'red'}
+              onClick={() => removeFocusNode(identifier)}
+            >
+              <MinusIcon />
+            </ActionIcon>
+          }
+        />
+      ))}
+    </Box>
+  );
+}

--- a/src/panels/GeoLocationPanel/AnchorPanels/EarthPanel/AddedCustomNodes.tsx
+++ b/src/panels/GeoLocationPanel/AnchorPanels/EarthPanel/AddedCustomNodes.tsx
@@ -11,15 +11,17 @@ interface Props {
   removeFocusNode: (identifier: Identifier) => void;
 }
 
-// This component is its own to reduce the amount of rerenders in
-// EarthPanel due to the `useWindowSize()` hook
 export function AddedCustomNodes({ addedNodes, removeFocusNode }: Props) {
   // TODO anden88 2025-02-07 Using the windowSize like this causes some stuttering when
   // moving the window panel. Investigation with Ylva we found that the culprit is most
   // likely the `ScrollArea` wrapping the entire window, possible solution is make own
   // scroll behaviour and instead wrap in e.g, `Box`
   const { width } = useWindowSize();
+  // The wrapping `Container` has a default padding of 16 on each side, so we compensate
+  // the width by the total padding
   const containerPadding = 36;
+  // The wrapping `Container` has a max-width of 925, capping the box at the same width
+  // to avoid it expanding further than that.
   const containerMaxWidth = 925;
 
   return addedNodes.length === 0 ? (

--- a/src/panels/GeoLocationPanel/AnchorPanels/EarthPanel/EarthEntry.tsx
+++ b/src/panels/GeoLocationPanel/AnchorPanels/EarthPanel/EarthEntry.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Group, Text } from '@mantine/core';
+import { ActionIcon, Group, Text, Tooltip } from '@mantine/core';
 import { computeDistanceBetween, LatLng } from 'spherical-geometry-js';
 
 import { NodeNavigationButton } from '@/components/NodeNavigationButton/NodeNavigationButton';
@@ -31,7 +31,6 @@ export function EarthEntry({
   const addressUtf8 = addressUTF8(address);
 
   const isAdded = isSceneGraphNodeAdded(addressUtf8);
-  const cappedAddress = address; // TODO cap address to some fixed size?
   const lat = place.location.y;
   const long = place.location.x;
   const alt = isCustomAltitude ? customAltitude * 1000 : calculateAltitude(place.extent);
@@ -53,22 +52,12 @@ export function EarthEntry({
   }
 
   return (
-    <Group key={address} gap={'xs'} mb={2} justify={'space-between'} wrap={'nowrap'}>
-      {/* TODO temporary css to stop long names from linebreaking causing the
-          buttons to be moved to a new row, the maxwidth is just arbitrary
-          minus the size of the buttons... */}
-      <Text
-        style={{
-          flexGrow: 1,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          textWrap: 'nowrap',
-          maxWidth: 350 - 125
-        }}
-      >
-        {cappedAddress}
-        {cappedAddress.length !== address.length ? '...' : ''}
-      </Text>
+    <Group key={address} gap={'xs'} justify={'space-between'} w={'100%'}>
+      <Tooltip label={address} withArrow openDelay={200}>
+        <Text truncate flex={1}>
+          {address}
+        </Text>
+      </Tooltip>
 
       <Group gap={'xs'} wrap={'nowrap'}>
         <NodeNavigationButton
@@ -91,7 +80,6 @@ export function EarthEntry({
               ? removeFocusNode(addressUtf8)
               : addFocusNode(addressUtf8, lat, long, alt)
           }
-          size={'lg'}
           color={isAdded ? 'red' : 'blue'}
         >
           {isAdded ? <MinusIcon /> : <PlusIcon />}

--- a/src/panels/GeoLocationPanel/AnchorPanels/EarthPanel/EarthPanel.tsx
+++ b/src/panels/GeoLocationPanel/AnchorPanels/EarthPanel/EarthPanel.tsx
@@ -1,9 +1,7 @@
 import { useState } from 'react';
 import {
-  ActionIcon,
   Button,
   Checkbox,
-  Container,
   Group,
   NumberInput,
   Tabs,
@@ -18,11 +16,11 @@ import { FilterList } from '@/components/FilterList/FilterList';
 import { generateMatcherFunctionByKeys } from '@/components/FilterList/util';
 import { ResizeableContent } from '@/components/ResizeableContent/ResizeableContent';
 import { SettingsPopout } from '@/components/SettingsPopout/SettingsPopout';
-import { MinusIcon } from '@/icons/icons';
 import { useAppSelector } from '@/redux/hooks';
 import { ArcGISJSON, Candidate, Identifier } from '@/types/types';
 import { GeoLocationGroupKey, ScenePrefixKey } from '@/util/keys';
 
+import { AddedCustomNodes } from './AddedCustomNodes';
 import { CustomCoordinates } from './CustomCoordinates';
 import { EarthEntry } from './EarthEntry';
 import { addressUTF8 } from './util';
@@ -229,33 +227,10 @@ export function EarthPanel({ currentAnchor }: Props) {
         </Tabs.Panel>
       </Tabs>
 
-      <Title order={2} my={'md'}>
+      <Title order={2} my={'xs'}>
         Added Nodes
       </Title>
-      {addedCustomNodes.length > 0 ? (
-        <Container my={'md'}>
-          {addedCustomNodes.map((identifier) => (
-            <Group gap={'xs'} key={identifier} mb={2}>
-              <ActionIcon onClick={() => removeFocusNode(identifier)} color={'red'}>
-                <MinusIcon />
-              </ActionIcon>
-              <Text
-                style={{
-                  flexGrow: 1,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  textWrap: 'nowrap',
-                  maxWidth: '300px'
-                }}
-              >
-                {identifier}
-              </Text>
-            </Group>
-          ))}
-        </Container>
-      ) : (
-        <Text>No added nodes</Text>
-      )}
+      <AddedCustomNodes addedNodes={addedCustomNodes} removeFocusNode={removeFocusNode} />
     </>
   );
 }

--- a/src/panels/Scene/SceneGraphNode/SceneGraphNodeHeader.tsx
+++ b/src/panels/Scene/SceneGraphNode/SceneGraphNodeHeader.tsx
@@ -15,7 +15,7 @@ interface Props {
   uri: Uri;
   label?: string;
   onClick?: () => void;
-  leftSection?: React.ReactNode;
+  leftSection?: React.ReactNode; // If specified, replaces the checkbox if the node has an attached renderable
 }
 
 export function SceneGraphNodeHeader({ uri, label, onClick, leftSection }: Props) {

--- a/src/panels/Scene/SceneGraphNode/SceneGraphNodeHeader.tsx
+++ b/src/panels/Scene/SceneGraphNode/SceneGraphNodeHeader.tsx
@@ -15,9 +15,10 @@ interface Props {
   uri: Uri;
   label?: string;
   onClick?: () => void;
+  leftSection?: React.ReactNode;
 }
 
-export function SceneGraphNodeHeader({ uri, label, onClick }: Props) {
+export function SceneGraphNodeHeader({ uri, label, onClick, leftSection }: Props) {
   const propertyOwner = useGetPropertyOwner(uri);
 
   const renderableUri = sgnRenderableUri(uri);
@@ -56,7 +57,8 @@ export function SceneGraphNodeHeader({ uri, label, onClick }: Props) {
     <ThreePartHeader
       title={onClick ? titleButton : name}
       leftSection={
-        hasRenderable && <PropertyOwnerVisibilityCheckbox uri={renderableUri} />
+        leftSection ??
+        (hasRenderable && <PropertyOwnerVisibilityCheckbox uri={renderableUri} />)
       }
       rightSection={
         <Group wrap={'nowrap'} gap={4}>


### PR DESCRIPTION
Fix text wrapping when searching for a place, change `Added Nodes` to use the SceneGraph header, this also fixes text wrapping in the exoplanets panel. 

Due to problems (probably with the ScrollArea) this does not fix text-wrapping in the scene tree. 