### PR TITLE
Update "no mission" view to look a bit nicer

### DIFF
--- a/src/panels/MissionsPanel/MissionsPanel.tsx
+++ b/src/panels/MissionsPanel/MissionsPanel.tsx
@@ -1,4 +1,4 @@
-import { CloseIcon, Stack, Text, ThemeIcon, Title } from '@mantine/core';
+import { Stack, Text, ThemeIcon, Title } from '@mantine/core';
 
 import { RocketLaunchIcon } from '@/icons/icons';
 import { useAppSelector } from '@/redux/hooks';

--- a/src/panels/MissionsPanel/MissionsPanel.tsx
+++ b/src/panels/MissionsPanel/MissionsPanel.tsx
@@ -1,5 +1,6 @@
-import { Text } from '@mantine/core';
+import { CloseIcon, Stack, Text, ThemeIcon, Title } from '@mantine/core';
 
+import { RocketLaunchIcon } from '@/icons/icons';
 import { useAppSelector } from '@/redux/hooks';
 
 import { MissionContent } from './MissionContent';
@@ -8,13 +9,19 @@ export function MissionsPanel() {
   const hasMission = useAppSelector((state) => state.missions.isInitialized);
   const mission = useAppSelector((state) => state.missions.data.missions[0]);
 
-  return (
-    <>
-      {hasMission ? (
-        <MissionContent missionOverview={mission} />
-      ) : (
-        <Text>No mission loaded</Text>
-      )}
-    </>
-  );
+  if (!hasMission) {
+    return (
+      <Stack h={'100%'} w={'100%'} ta={'center'} align={'center'} p={'lg'}>
+        <Title order={2}>No mission loaded</Title>
+        <Text c={'dimmed'}>
+          Open an asset that contains a mission, or load a mission profile.
+        </Text>
+        <ThemeIcon size={100} variant={'transparent'}>
+          <RocketLaunchIcon size={'100px'} />
+        </ThemeIcon>
+      </Stack>
+    );
+  }
+
+  return <MissionContent missionOverview={mission} />;
 }


### PR DESCRIPTION
Inspired by the Skybrowser panel when no browser is added

![image](https://github.com/user-attachments/assets/bd3308b8-a390-43c7-8c2b-420c80743461)
