### PR TITLE
Add touch and focus support for infobox tooltips

### DIFF
--- a/src/components/InfoBox/InfoBox.tsx
+++ b/src/components/InfoBox/InfoBox.tsx
@@ -9,8 +9,14 @@ interface Props {
 
 export function InfoBox({ text, w = 220 }: Props) {
   return (
-    <Tooltip label={text} multiline w={w} offset={{ mainAxis: 5, crossAxis: 100 }}>
-      <ThemeIcon radius={'xl'} size={'xs'}>
+    <Tooltip
+      label={text}
+      multiline
+      w={w}
+      offset={{ mainAxis: 5, crossAxis: 100 }}
+      events={{ hover: true, focus: true, touch: true }}
+    >
+      <ThemeIcon tabIndex={0} radius={'xl'} size={'xs'}>
         <InformationIcon />
       </ThemeIcon>
     </Tooltip>


### PR DESCRIPTION
Realized that Mantine already had support for accessible tooltips, and for touch!  
https://mantine.dev/core/tooltip/#accessibility

Applied those settings for our infoboxes, but we should check if it's good enough for our touch use-case. 

Let me know if you think this solution is good enough, or if we should do something more advanced