### PR TITLE
add mission selection if multiple ones are loaded

### DIFF
--- a/src/panels/MissionsPanel/MissionContent.tsx
+++ b/src/panels/MissionsPanel/MissionContent.tsx
@@ -23,6 +23,7 @@ export function MissionContent({ missionOverview }: Props) {
     data: undefined
   });
 
+  // Reset phases when selected mission is changed
   useEffect(() => {
     // When the mission is changed, display overview again
     setDisplayedPhase({

--- a/src/panels/MissionsPanel/MissionContent.tsx
+++ b/src/panels/MissionsPanel/MissionContent.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Box, Button, Group, Switch, Text, Title } from '@mantine/core';
 
 import { useSubscribeToTime } from '@/api/hooks';
@@ -22,6 +22,20 @@ export function MissionContent({ missionOverview }: Props) {
     type: undefined,
     data: undefined
   });
+
+  useEffect(() => {
+    // When the mission is changed, display overview again
+    setDisplayedPhase({
+      type: DisplayType.Overview,
+      data: missionOverview
+    });
+    // Avoid potentially showing information from a previous mission
+    setLastDisplayedPhase({
+      type: DisplayType.Overview,
+      data: missionOverview
+    });
+    setDisplayCurrentPhase(false);
+  }, [missionOverview]);
 
   const now = useSubscribeToTime();
 
@@ -104,14 +118,14 @@ export function MissionContent({ missionOverview }: Props) {
   }
 
   return (
-    <Group wrap={'nowrap'} align={'start'} h={'100%'} gap={0}>
+    <Group wrap={'nowrap'} align={'start'} gap={'xs'}>
       <TimeLine
         allPhasesNested={allPhasesNested}
         displayedPhase={displayedPhase}
         missionOverview={missionOverview}
         setDisplayedPhase={setPhaseManually}
       />
-      <Box px={'md'} h={'100%'} style={{ overflow: 'auto' }}>
+      <Box flex={1}>
         <Group justify={'space-between'} mb={'md'}>
           <Title order={2}>{missionOverview.name}</Title>
           <Button

--- a/src/panels/MissionsPanel/MissionsPanel.tsx
+++ b/src/panels/MissionsPanel/MissionsPanel.tsx
@@ -5,15 +5,19 @@ import { RocketLaunchIcon } from '@/icons/icons';
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
 import { setSelectedMission } from '@/redux/missions/missionsSlice';
 
-import { useSelectedMission } from './hooks';
 import { MissionContent } from './MissionContent';
 
 export function MissionsPanel() {
-  const { data, selectedMissionIdentifier } = useAppSelector((state) => state.missions);
+  const { isInitialized, missions, selectedMissionIdentifier } = useAppSelector(
+    (state) => state.missions
+  );
 
   const luaApi = useOpenSpaceApi();
-  const { hasMission, mission } = useSelectedMission();
   const dispatch = useAppDispatch();
+
+  // Grab the mission last viewed or if it does not exist anymore, take the first one
+  const mission = missions[selectedMissionIdentifier] ?? Object.values(missions)[0];
+  const hasMission = isInitialized && mission !== undefined;
 
   function onMissionSelected(identifier: string | null) {
     if (!identifier) {
@@ -39,12 +43,12 @@ export function MissionsPanel() {
 
   return (
     <Box>
-      {data.missions.length > 1 && (
+      {Object.keys(missions).length > 1 && (
         <Select
           label={'Selected mission'}
           placeholder={'Select a mission'}
-          data={data.missions.map((mission) => {
-            return { value: mission.identifier, label: mission.name };
+          data={Object.entries(missions).map(([identifier, mission]) => {
+            return { value: identifier, label: mission.name };
           })}
           value={selectedMissionIdentifier}
           onChange={onMissionSelected}

--- a/src/panels/MissionsPanel/MissionsPanel.tsx
+++ b/src/panels/MissionsPanel/MissionsPanel.tsx
@@ -15,9 +15,7 @@ export function MissionsPanel() {
   const luaApi = useOpenSpaceApi();
   const dispatch = useAppDispatch();
 
-  // Grab the mission last viewed or if it does not exist anymore, take the first one
-  const mission = missions[selectedMissionIdentifier] ?? Object.values(missions)[0];
-  const hasMission = isInitialized && mission !== undefined;
+  const hasMission = isInitialized && Object.values(missions).length > 0;
 
   function onMissionSelected(identifier: string | null) {
     if (!identifier) {
@@ -27,7 +25,7 @@ export function MissionsPanel() {
     luaApi?.setCurrentMission(identifier);
   }
 
-  if (!hasMission || !mission) {
+  if (!hasMission) {
     return (
       <Stack h={'100%'} w={'100%'} ta={'center'} align={'center'} p={'lg'}>
         <Title order={2}>No mission loaded</Title>
@@ -40,6 +38,9 @@ export function MissionsPanel() {
       </Stack>
     );
   }
+
+  // Grab the mission last viewed or if it does not exist anymore, take the first one
+  const mission = missions[selectedMissionIdentifier] ?? Object.values(missions)[0];
 
   return (
     <Box>

--- a/src/panels/MissionsPanel/MissionsPanel.tsx
+++ b/src/panels/MissionsPanel/MissionsPanel.tsx
@@ -23,7 +23,7 @@ export function MissionsPanel() {
     luaApi?.setCurrentMission(identifier);
   }
 
-  if (!hasMission) {
+  if (!hasMission || !mission) {
     return (
       <Stack h={'100%'} w={'100%'} ta={'center'} align={'center'} p={'lg'}>
         <Title order={2}>No mission loaded</Title>
@@ -52,7 +52,7 @@ export function MissionsPanel() {
           allowDeselect={false}
         />
       )}
-      <MissionContent missionOverview={mission!} />
+      <MissionContent missionOverview={mission} />
     </Box>
   );
 }

--- a/src/panels/MissionsPanel/MissionsPanel.tsx
+++ b/src/panels/MissionsPanel/MissionsPanel.tsx
@@ -5,29 +5,15 @@ import { RocketLaunchIcon } from '@/icons/icons';
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
 import { setSelectedMission } from '@/redux/missions/missionsSlice';
 
+import { useSelectedMission } from './hooks';
 import { MissionContent } from './MissionContent';
 
 export function MissionsPanel() {
-  const {
-    isInitialized: hasMission,
-    data,
-    selectedMissionIdentifier
-  } = useAppSelector((state) => state.missions);
+  const { data, selectedMissionIdentifier } = useAppSelector((state) => state.missions);
 
   const luaApi = useOpenSpaceApi();
+  const { hasMission, mission } = useSelectedMission();
   const dispatch = useAppDispatch();
-
-  let [mission] = data.missions;
-  // If a new missions is added, the missions order might have changed so we try to find
-  // the last one viewed
-  if (hasMission && selectedMissionIdentifier) {
-    const selectedMission = data.missions.find(
-      (_mission) => _mission.identifier === selectedMissionIdentifier
-    );
-    if (selectedMission) {
-      mission = selectedMission;
-    }
-  }
 
   function onMissionSelected(identifier: string | null) {
     if (!identifier) {
@@ -57,8 +43,8 @@ export function MissionsPanel() {
         <Select
           label={'Selected mission'}
           placeholder={'Select a mission'}
-          data={data.missions.map((_mission) => {
-            return { value: _mission.identifier, label: _mission.name };
+          data={data.missions.map((mission) => {
+            return { value: mission.identifier, label: mission.name };
           })}
           value={selectedMissionIdentifier}
           onChange={onMissionSelected}
@@ -66,7 +52,7 @@ export function MissionsPanel() {
           allowDeselect={false}
         />
       )}
-      <MissionContent missionOverview={mission} />
+      <MissionContent missionOverview={mission!} />
     </Box>
   );
 }

--- a/src/panels/MissionsPanel/hooks.ts
+++ b/src/panels/MissionsPanel/hooks.ts
@@ -1,5 +1,8 @@
 import { useOpenSpaceApi, useSubscribeToTime } from '@/api/hooks';
+import { useAppSelector } from '@/redux/hooks';
 import { isDateValid } from '@/redux/time/util';
+
+import { Phase } from './types';
 
 type ReturnType = (time: string) => void;
 
@@ -38,4 +41,32 @@ export function useJumpToTime(fadeTime: number = 1): ReturnType {
       luaApi?.time.interpolateTime(utcDate.toISOString(), fadeTime);
     }
   };
+}
+
+export function useSelectedMission(): {
+  mission: Phase | undefined;
+  hasMission: boolean;
+} {
+  const { isInitialized, data, selectedMissionIdentifier } = useAppSelector(
+    (state) => state.missions
+  );
+
+  let mission: Phase | undefined = undefined;
+
+  // If a new mission is added, the missions order might have changed so we try to find
+  // the last one viewed
+  if (isInitialized && selectedMissionIdentifier) {
+    const selectedMission = data.missions.find(
+      (mission) => mission.identifier === selectedMissionIdentifier
+    );
+    if (selectedMission) {
+      mission = selectedMission;
+    } else {
+      mission = data.missions.at(0);
+    }
+  }
+
+  const hasMission = isInitialized && mission !== undefined;
+
+  return { hasMission, mission };
 }

--- a/src/panels/MissionsPanel/hooks.ts
+++ b/src/panels/MissionsPanel/hooks.ts
@@ -1,8 +1,5 @@
 import { useOpenSpaceApi, useSubscribeToTime } from '@/api/hooks';
-import { useAppSelector } from '@/redux/hooks';
 import { isDateValid } from '@/redux/time/util';
-
-import { Phase } from './types';
 
 type ReturnType = (time: string) => void;
 
@@ -41,32 +38,4 @@ export function useJumpToTime(fadeTime: number = 1): ReturnType {
       luaApi?.time.interpolateTime(utcDate.toISOString(), fadeTime);
     }
   };
-}
-
-export function useSelectedMission(): {
-  mission: Phase | undefined;
-  hasMission: boolean;
-} {
-  const { isInitialized, data, selectedMissionIdentifier } = useAppSelector(
-    (state) => state.missions
-  );
-
-  let mission: Phase | undefined = undefined;
-
-  // If a new mission is added, the missions order might have changed so we try to find
-  // the last one viewed
-  if (isInitialized && selectedMissionIdentifier) {
-    const selectedMission = data.missions.find(
-      (mission) => mission.identifier === selectedMissionIdentifier
-    );
-    if (selectedMission) {
-      mission = selectedMission;
-    } else {
-      mission = data.missions.at(0);
-    }
-  }
-
-  const hasMission = isInitialized && mission !== undefined;
-
-  return { hasMission, mission };
 }

--- a/src/panels/MissionsPanel/types.ts
+++ b/src/panels/MissionsPanel/types.ts
@@ -19,9 +19,9 @@ export interface Phase {
   link: string;
   milestones: Milestone[];
   capturetimes: string[];
-  identifier: Identifier; // TOOD anden88 2025-03-03: The identifier only exists on the outermost
-  // phase object, refactor the phase Object into a Mission type that includes the phases and captureTimes?
 }
+
+export type Missions = Record<Identifier, Phase>;
 
 export type DisplayedPhase =
   | { type: DisplayType.Phase; data: Phase }

--- a/src/panels/MissionsPanel/types.ts
+++ b/src/panels/MissionsPanel/types.ts
@@ -1,3 +1,5 @@
+import { Identifier } from '@/types/types';
+
 export interface Milestone {
   date: string; // Date as an UTC ISO8601 string
   name: string;
@@ -17,7 +19,7 @@ export interface Phase {
   link: string;
   milestones: Milestone[];
   capturetimes: string[];
-  identifier: string; // TOOD anden88 2025-03-03: The identifier only exists on the outermost
+  identifier: Identifier; // TOOD anden88 2025-03-03: The identifier only exists on the outermost
   // phase object, refactor the phase Object into a Mission type that includes the phases and captureTimes?
 }
 

--- a/src/panels/MissionsPanel/types.ts
+++ b/src/panels/MissionsPanel/types.ts
@@ -17,6 +17,8 @@ export interface Phase {
   link: string;
   milestones: Milestone[];
   capturetimes: string[];
+  identifier: string; // TOOD anden88 2025-03-03: The identifier only exists on the outermost
+  // phase object, refactor the phase Object into a Mission type that includes the phases and captureTimes?
 }
 
 export type DisplayedPhase =

--- a/src/redux/events/eventsMiddleware.ts
+++ b/src/redux/events/eventsMiddleware.ts
@@ -45,8 +45,6 @@ export const setupEventsSubscription = createAsyncThunk(
           thunkAPI.dispatch(removeAction(data.Uri));
           break;
         case 'MissionAdded':
-          thunkAPI.dispatch(refreshMissions());
-          break;
         case 'MissionRemoved':
           thunkAPI.dispatch(refreshMissions());
           break;

--- a/src/redux/events/eventsMiddleware.ts
+++ b/src/redux/events/eventsMiddleware.ts
@@ -12,6 +12,8 @@ import {
 } from '@/redux/propertytree/propertyTreeMiddleware';
 import { ConnectionStatus } from '@/types/enums';
 
+import { refreshMissions } from '../missions/missionsMiddleware';
+
 import { EventData } from './types';
 
 let eventTopic: Topic;
@@ -41,6 +43,12 @@ export const setupEventsSubscription = createAsyncThunk(
           break;
         case 'ActionRemoved':
           thunkAPI.dispatch(removeAction(data.Uri));
+          break;
+        case 'MissionAdded':
+          thunkAPI.dispatch(refreshMissions());
+          break;
+        case 'MissionRemoved':
+          thunkAPI.dispatch(refreshMissions());
           break;
         default:
           break;

--- a/src/redux/events/types.ts
+++ b/src/redux/events/types.ts
@@ -64,8 +64,18 @@ type InterpolationFinishedEvent = {
   Property: Uri;
 };
 
+type MissionAddedEvent = {
+  Event: 'MissionAdded';
+  MissionName: string;
+};
+
 type MissionEventReachedEvent = {
   Event: 'MissionEventReached';
+};
+
+type MissionRemovedEvent = {
+  Event: 'MissionRemoved';
+  MissionName: string;
 };
 
 type ParallelConnectionEvent = {
@@ -134,7 +144,9 @@ export type EventData =
   | FocusNodeChangedEvent
   | GuiTreeUpdatedEvent
   | InterpolationFinishedEvent
+  | MissionAddedEvent
   | MissionEventReachedEvent
+  | MissionRemovedEvent
   | ParallelConnectionEvent
   | PlanetEclipsedEvent
   | PointSpacecraftEvent

--- a/src/redux/missions/missionsMiddleware.ts
+++ b/src/redux/missions/missionsMiddleware.ts
@@ -1,7 +1,7 @@
 import { createAction, createAsyncThunk } from '@reduxjs/toolkit';
 
 import { api } from '@/api/api';
-import { Phase } from '@/panels/MissionsPanel/types';
+import { Missions } from '@/panels/MissionsPanel/types';
 import { onOpenConnection } from '@/redux/connection/connectionSlice';
 import type { AppStartListening } from '@/redux/listenerMiddleware';
 
@@ -12,7 +12,7 @@ export const refreshMissions = createAction<void>('missions/refreshMissions');
 interface MissionData {
   done: boolean;
   value: {
-    missions: Phase[] | null;
+    missions: Missions | null;
   };
 }
 
@@ -20,7 +20,7 @@ const getMissions = createAsyncThunk('missions/getMissions', async (_, thunkAPI)
   const missionTopic = api.startTopic('missions', {});
   const { value } = (await missionTopic.iterator().next()) as MissionData;
   if (value.missions) {
-    thunkAPI.dispatch(initializeMissions({ missions: value.missions }));
+    thunkAPI.dispatch(initializeMissions(value.missions));
   } else {
     thunkAPI.dispatch(clearMissions());
   }

--- a/src/redux/missions/missionsSlice.ts
+++ b/src/redux/missions/missionsSlice.ts
@@ -5,13 +5,15 @@ import { Phase } from '@/panels/MissionsPanel/types';
 export interface MissionState {
   isInitialized: boolean;
   data: { missions: Phase[] };
+  selectedMissionIdentifier: string;
 }
 
 const initialState: MissionState = {
   isInitialized: false,
   data: {
     missions: []
-  }
+  },
+  selectedMissionIdentifier: ''
 };
 
 function makeUTCString(time: string): string {
@@ -44,11 +46,31 @@ export const missionsSlice = createSlice({
     initializeMissions: (state, action: PayloadAction<{ missions: Phase[] }>) => {
       state.isInitialized = true;
       state.data.missions = action.payload.missions.map(convertPhaseToUTC);
+
+      // If no mission was loaded or if the previously selected mission was removed,
+      // automatically select first available mission from the updated list
+      const isSelectedMissionLoaded = state.data.missions.some(
+        (mission) => mission.identifier === state.selectedMissionIdentifier
+      );
+      if (!isSelectedMissionLoaded) {
+        state.selectedMissionIdentifier = action.payload.missions[0].identifier;
+      }
+      return state;
+    },
+    clearMissions: (state) => {
+      state.isInitialized = false;
+      state.data.missions = [];
+      state.selectedMissionIdentifier = '';
+      return state;
+    },
+    setSelectedMission: (state, action: PayloadAction<string>) => {
+      state.selectedMissionIdentifier = action.payload;
       return state;
     }
   }
 });
 
 // Action creators are generated for each case reducer function, replaces the `Actions/index.js`
-export const { initializeMissions } = missionsSlice.actions;
+export const { initializeMissions, clearMissions, setSelectedMission } =
+  missionsSlice.actions;
 export const missionsReducer = missionsSlice.reducer;


### PR DESCRIPTION
Requires latest OpenSpace gui branch [here](https://github.com/OpenSpace/OpenSpace/commit/9fa57a47b8b9142a97d2f25934dafda5edd57642)

You can now load multiple mission files and select which one you want to view. 
Remembers which mission was last viewed if the panel is closed
Keep the same mission viewed if more are loaded at runtime
Fallback to first mission file in list if the one viewed is removed
