### PR TITLE
Create interface that extends TreeNodeData and add the guipath to it

### DIFF
--- a/src/panels/Scene/SceneTree/FeaturedSceneTree.tsx
+++ b/src/panels/Scene/SceneTree/FeaturedSceneTree.tsx
@@ -1,4 +1,4 @@
-import { Tree, TreeNodeData } from '@mantine/core';
+import { Tree } from '@mantine/core';
 
 import { useGetStringPropertyValue } from '@/api/hooks';
 import { useAppSelector } from '@/redux/hooks';
@@ -10,6 +10,7 @@ import {
 } from '@/util/sceneTreeGroupsHelper';
 
 import { SceneTreeNode } from './SceneTreeNode';
+import { SceneTreeNodeData } from './types';
 
 /**
  * This component displays the current focus and aim of the camera, as well as the list of
@@ -21,7 +22,7 @@ export function FeaturedSceneTree() {
   const [anchor] = useGetStringPropertyValue(NavigationAnchorKey);
   const [aim] = useGetStringPropertyValue(NavigationAimKey);
 
-  const featuredTreeData: TreeNodeData[] = [];
+  const featuredTreeData: SceneTreeNodeData[] = [];
 
   if (anchor) {
     const anchorData = treeDataForSceneGraphNode(sgnUri(anchor), propertyOwners);
@@ -35,7 +36,7 @@ export function FeaturedSceneTree() {
     featuredTreeData.push(aimData);
   }
 
-  const interestingNodes: TreeNodeData[] = [];
+  const interestingNodes: SceneTreeNodeData[] = [];
   const propertyOwnersScene = propertyOwners.Scene?.subowners ?? [];
   propertyOwnersScene.forEach((uri) => {
     if (hasInterestingTag(uri, propertyOwners)) {

--- a/src/panels/Scene/SceneTree/SceneTree.tsx
+++ b/src/panels/Scene/SceneTree/SceneTree.tsx
@@ -6,7 +6,6 @@ import {
   Group,
   Tooltip,
   Tree,
-  TreeNodeData,
   useTree
 } from '@mantine/core';
 
@@ -27,6 +26,7 @@ import {
   SceneTreeFilterSettings,
   sortTreeData
 } from './treeUtil';
+import { SceneTreeNodeData } from './types';
 
 export function SceneTree() {
   const [filter, setFilter] = useState<SceneTreeFilterSettings>({
@@ -98,7 +98,7 @@ export function SceneTree() {
 
   // @TODO (2025-01-13 emmbr): Would be nice to sort the results by some type of
   // "relevance", but for now we just sort alphabetically
-  flatTreeData.sort((a: TreeNodeData, b: TreeNodeData) => {
+  flatTreeData.sort((a: SceneTreeNodeData, b: SceneTreeNodeData) => {
     const nameA = a.label as string;
     const nameB = b.label as string;
     return nameA.toLocaleLowerCase().localeCompare(nameB.toLocaleLowerCase());
@@ -137,10 +137,10 @@ export function SceneTree() {
 
       <FilterList.SearchResults
         data={flatTreeData}
-        renderElement={(node: TreeNodeData) => (
+        renderElement={(node: SceneTreeNodeData) => (
           <SceneTreeNodeContent key={node.value} node={node} expanded={false} />
         )}
-        matcherFunc={generateMatcherFunctionByKeys(['label'])} // For now we just use the name
+        matcherFunc={generateMatcherFunctionByKeys(['label', 'guiPath'])} // For now we just use the name
       >
         <FilterList.SearchResults.VirtualList />
       </FilterList.SearchResults>

--- a/src/panels/Scene/SceneTree/SceneTreeNode.tsx
+++ b/src/panels/Scene/SceneTree/SceneTreeNode.tsx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { Box, RenderTreeNodePayload, TreeNodeData } from '@mantine/core';
+import { Box, RenderTreeNodePayload } from '@mantine/core';
 import { useWindowEvent } from '@mantine/hooks';
 
 import { CollapsableHeader } from '@/components/Collapsable/CollapsableHeader/CollapsableHeader';
@@ -11,9 +11,10 @@ import { useOpenCurrentSceneNodeWindow } from '../hooks';
 import { SceneGraphNodeHeader } from '../SceneGraphNode/SceneGraphNodeHeader';
 
 import { CurrentNodeView } from './CurrentNodeView';
+import { SceneTreeNodeData } from './types';
 
 interface Props {
-  node: TreeNodeData;
+  node: SceneTreeNodeData;
   expanded: boolean;
 }
 

--- a/src/panels/Scene/SceneTree/treeUtil.ts
+++ b/src/panels/Scene/SceneTree/treeUtil.ts
@@ -7,6 +7,7 @@ import {
   isSceneGraphNodeVisible
 } from '@/util/propertyTreeHelpers';
 import { isGroupNode, SceneTreeGroupPrefixKey } from '@/util/sceneTreeGroupsHelper';
+import { SceneTreeNodeData } from './types';
 
 /****************************************************************************************
  * FILTERING
@@ -19,11 +20,11 @@ export interface SceneTreeFilterSettings {
 }
 
 export function filterTreeData(
-  nodes: TreeNodeData[],
+  nodes: SceneTreeNodeData[],
   filter: SceneTreeFilterSettings,
   properties: Properties,
   propertyOwners: PropertyOwners
-): TreeNodeData[] {
+): SceneTreeNodeData[] {
   // Should the scene graph node be shown based on the current filter settings?
   function shouldShowSceneGraphNode(uri: Uri) {
     let shouldShow = true;
@@ -42,7 +43,7 @@ export function filterTreeData(
   // Recursively apply filtering to one node in the tree. That is, if the node is a group,
   // filter its children. Set the nodes that should be filtered out to null, so that the
   // filtering can be done in a separate step.
-  function recursivelyFilterSubTree(node: TreeNodeData): TreeNodeData | null {
+  function recursivelyFilterSubTree(node: SceneTreeNodeData): SceneTreeNodeData | null {
     const newNode = { ...node };
     if (isGroupNode(newNode)) {
       // Groups => filter children
@@ -87,13 +88,13 @@ interface TreeSortingInfo {
 }
 
 export function createTreeSortingInformation(
-  treeData: TreeNodeData[],
+  treeData: SceneTreeNodeData[],
   properties: Properties
 ): TreeSortingInfo {
   const result: TreeSortingInfo = {};
 
   // Recursively add the sorting information for a node in the tree
-  function addNode(node: TreeNodeData) {
+  function addNode(node: SceneTreeNodeData) {
     if (isGroupNode(node)) {
       const groupPath = node.value.replace(SceneTreeGroupPrefixKey, '');
       result[node.value] = {
@@ -129,16 +130,16 @@ export function createTreeSortingInformation(
  * multiple alternative ways to specify the order.
  */
 export function sortTreeLevel(
-  treeListToSort: TreeNodeData[],
+  treeListToSort: SceneTreeNodeData[],
   treeSortingInfo: TreeSortingInfo,
   customOrderNamesList: string[] | undefined
-): TreeNodeData[] {
+): SceneTreeNodeData[] {
   // Split the list up into three: 1) Any custom sorted objects, 2) numerically sorted
   // objects, and 3) alphabetically sorted. In most cases, all will be alphabetical.
 
-  const customOrder: TreeNodeData[] = [];
-  const numericalOrder: TreeNodeData[] = [];
-  const alphabeticalOrder: TreeNodeData[] = [];
+  const customOrder: SceneTreeNodeData[] = [];
+  const numericalOrder: SceneTreeNodeData[] = [];
+  const alphabeticalOrder: SceneTreeNodeData[] = [];
 
   // In most cases there will be no custom ordering, so just use an empty array
   const orderedNames = customOrderNamesList || [];
@@ -213,10 +214,10 @@ export function sortTreeLevel(
 }
 
 export function sortTreeData(
-  treeData: TreeNodeData[],
+  treeData: SceneTreeNodeData[],
   customGuiOrderingMap: CustomGroupOrdering,
   properties: Properties
-): TreeNodeData[] {
+): SceneTreeNodeData[] {
   const treeSortingInfo = createTreeSortingInformation(treeData, properties);
 
   // Start with sorting the top level groups in the tree
@@ -225,7 +226,7 @@ export function sortTreeData(
 
   // Then sort the children of each group, recursively
   function resursiveSortChildren(
-    nodes: TreeNodeData[],
+    nodes: SceneTreeNodeData[],
     treeSortingInfo: TreeSortingInfo
   ) {
     return nodes.map((node) => {
@@ -250,10 +251,10 @@ export function sortTreeData(
  * The searching requires a flat list of all nodes in the tree. This function flattens the
  * tree data structure into a list of nodes.
  */
-export function flattenTreeData(treeData: TreeNodeData[]): TreeNodeData[] {
-  const flatData: TreeNodeData[] = [];
+export function flattenTreeData(treeData: SceneTreeNodeData[]): SceneTreeNodeData[] {
+  const flatData: SceneTreeNodeData[] = [];
 
-  function flatten(nodes: TreeNodeData[]) {
+  function flatten(nodes: SceneTreeNodeData[]) {
     nodes.forEach((node) => {
       if (node.children) {
         flatten(node.children);

--- a/src/panels/Scene/SceneTree/types.ts
+++ b/src/panels/Scene/SceneTree/types.ts
@@ -1,0 +1,5 @@
+import { TreeNodeData } from '@mantine/core';
+
+export interface SceneTreeNodeData extends TreeNodeData {
+  guiPath?: string[];
+}

--- a/src/redux/groups/groupsSlice.ts
+++ b/src/redux/groups/groupsSlice.ts
@@ -2,11 +2,12 @@ import { TreeNodeData } from '@mantine/core';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { CustomGroupOrdering, Groups } from '@/types/types';
+import { SceneTreeNodeData } from '@/panels/Scene/SceneTree/treeUtil';
 
 export interface GroupsState {
   customGroupOrdering: CustomGroupOrdering;
   groups: Groups;
-  sceneTreeData: TreeNodeData[];
+  sceneTreeData: SceneTreeNodeData[];
   tags: string[];
 }
 
@@ -25,7 +26,7 @@ export const groupsSlice = createSlice({
       state.groups = action.payload;
       return state;
     },
-    setSceneTreeData: (state, action: PayloadAction<TreeNodeData[]>) => {
+    setSceneTreeData: (state, action: PayloadAction<SceneTreeNodeData[]>) => {
       state.sceneTreeData = action.payload;
       return state;
     },

--- a/src/util/sceneTreeGroupsHelper.ts
+++ b/src/util/sceneTreeGroupsHelper.ts
@@ -1,8 +1,7 @@
-import { TreeNodeData } from '@mantine/core';
-
 import { Group, Groups, Properties, PropertyOwners, Uri } from '@/types/types';
 
 import { getGuiPath, isSceneGraphNode } from './propertyTreeHelpers';
+import { SceneTreeNodeData } from '@/panels/Scene/SceneTree/types';
 
 // This key is added to the group path values in the tree data structure, to mark which
 // tree nodes correspond to groups (as opposed to scene graph nodes).
@@ -16,7 +15,7 @@ function emptyGroup(): Group {
  * Check if a node in the Scene tree is a group node, meaning that its identifiing value
  * starts with the specified prefix.
  */
-export function isGroupNode(node: TreeNodeData): boolean {
+export function isGroupNode(node: SceneTreeNodeData): boolean {
   return node.value.startsWith(SceneTreeGroupPrefixKey);
 }
 
@@ -69,12 +68,14 @@ export function computeGroups(
  */
 export function treeDataForSceneGraphNode(
   uri: Uri,
-  propertyOwners: PropertyOwners
-): TreeNodeData {
+  propertyOwners: PropertyOwners,
+  path?: string
+): SceneTreeNodeData {
   const propertyOwner = propertyOwners[uri];
   return {
     label: propertyOwner?.name || '',
-    value: uri
+    value: uri,
+    guiPath: path?.split('/') ?? []
   };
 }
 
@@ -84,8 +85,8 @@ export function treeDataForSceneGraphNode(
 export function sceneTreeDataFromGroups(
   groups: Groups,
   propertyOwners: PropertyOwners
-): TreeNodeData[] {
-  const treeData: TreeNodeData[] = [];
+): SceneTreeNodeData[] {
+  const treeData: SceneTreeNodeData[] = [];
 
   const topLevelGroupsPaths = Object.keys(groups).filter((path) => {
     // Get the number of slashes in the path
@@ -98,10 +99,11 @@ export function sceneTreeDataFromGroups(
     const splitPath = path.split('/');
     const name = splitPath.length > 1 ? splitPath.pop() : 'Untitled';
 
-    const groupNodeData: TreeNodeData = {
+    const groupNodeData: SceneTreeNodeData = {
       value: SceneTreeGroupPrefixKey + path,
       label: name,
-      children: []
+      children: [],
+      guiPath: path.split('/')
     };
 
     const groupData = groups[path];
@@ -113,7 +115,7 @@ export function sceneTreeDataFromGroups(
 
     // Add property owners, also recursively
     groupData.propertyOwners.forEach((uri) => {
-      groupNodeData.children?.push(treeDataForSceneGraphNode(uri, propertyOwners));
+      groupNodeData.children?.push(treeDataForSceneGraphNode(uri, propertyOwners, path));
     });
 
     return groupNodeData;


### PR DESCRIPTION
* Now we can search for subfolders

The drawback of this is that we get a lot more search results... I'm not really sure what I think about it. One one hand, it is nice, because we can easier find things, but it also is weird that when you search for "Earth", it shows up second. On the other hand, this behavior could be fixed with a "matching score", which we might want to implement anyway - it is not certain that we display things in a good order anyway.

One option is to only search on the leaf folder, but that seems a bit weird to me. 

Do we also want to be able to search for folder in the navigation panel?

What do you guys think?