### PR TITLE
Increase infobox tooltip text width

### DIFF
--- a/src/components/InfoBox/InfoBox.tsx
+++ b/src/components/InfoBox/InfoBox.tsx
@@ -7,7 +7,7 @@ interface Props {
   w?: number;
 }
 
-export function InfoBox({ text, w = 300 }: Props) {
+export function InfoBox({ text, w = 320 }: Props) {
   return (
     <Tooltip label={text} multiline maw={w} offset={{ mainAxis: 5, crossAxis: 100 }}>
       <ThemeIcon radius={'xl'} size={'xs'}>

--- a/src/components/InfoBox/InfoBox.tsx
+++ b/src/components/InfoBox/InfoBox.tsx
@@ -7,7 +7,7 @@ interface Props {
   w?: number;
 }
 
-export function InfoBox({ text, w = 220 }: Props) {
+export function InfoBox({ text, w = 300 }: Props) {
   return (
     <Tooltip label={text} multiline maw={w} offset={{ mainAxis: 5, crossAxis: 100 }}>
       <ThemeIcon radius={'xl'} size={'xs'}>


### PR DESCRIPTION
Set the line width to correspond to roughly 50 character per line => good readability.

Seems to look ok even for shorter texts

Before: 
![image](https://github.com/user-attachments/assets/8a05c5ab-31e0-40cf-9792-9a5637dfffa1)

After:
![image](https://github.com/user-attachments/assets/c89cca68-50d9-462b-a04c-d6af26436350)

Shorter text:
![image](https://github.com/user-attachments/assets/011812df-81be-4325-a466-3204d9bf8d23)
