### PR TITLE
Feature/make scene panel not split emmasuggestion

### DIFF
--- a/src/panels/Scene/SceneGraphNode/OpenInNewWindowButton.tsx
+++ b/src/panels/Scene/SceneGraphNode/OpenInNewWindowButton.tsx
@@ -1,0 +1,38 @@
+import { ActionIcon } from '@mantine/core';
+
+import { usePropertyOwner } from '@/hooks/propertyOwner';
+import { OpenInNewIcon } from '@/icons/icons';
+import { Uri } from '@/types/types';
+import { displayName } from '@/util/propertyTreeHelpers';
+import { useWindowLayoutProvider } from '@/windowmanagement/WindowLayout/hooks';
+
+import { SceneGraphNodeView } from './SceneGraphNodeView';
+
+interface Props {
+  uri: Uri;
+}
+
+export function OpenInNewWindowButton({ uri }: Props) {
+  const propertyOwner = usePropertyOwner(uri);
+  const { addWindow } = useWindowLayoutProvider();
+
+  if (!propertyOwner) {
+    return <></>;
+  }
+
+  const name = displayName(propertyOwner);
+
+  function openInNewWindow() {
+    addWindow(<SceneGraphNodeView uri={uri} showOpenInNewWindow={false} />, {
+      id: 'sgn-' + uri,
+      title: name,
+      position: 'float'
+    });
+  }
+
+  return (
+    <ActionIcon onClick={openInNewWindow} size={'sm'} flex={0}>
+      <OpenInNewIcon />
+    </ActionIcon>
+  );
+}

--- a/src/panels/Scene/SceneGraphNode/OpenSgnInNewWindowButton.tsx
+++ b/src/panels/Scene/SceneGraphNode/OpenSgnInNewWindowButton.tsx
@@ -12,7 +12,7 @@ interface Props {
   uri: Uri;
 }
 
-export function OpenInNewWindowButton({ uri }: Props) {
+export function OpenSgnInNewWindowButton({ uri }: Props) {
   const propertyOwner = usePropertyOwner(uri);
   const { addWindow } = useWindowLayoutProvider();
 

--- a/src/panels/Scene/SceneGraphNode/SceneGraphNodeHeader.tsx
+++ b/src/panels/Scene/SceneGraphNode/SceneGraphNodeHeader.tsx
@@ -1,41 +1,36 @@
-import { ActionIcon, Button, Group, Text } from '@mantine/core';
+import { Button, Group, Text } from '@mantine/core';
 
 import { NodeNavigationButton } from '@/components/NodeNavigationButton/NodeNavigationButton';
 import { PropertyOwnerVisibilityCheckbox } from '@/components/PropertyOwner/VisiblityCheckbox';
 import { ThreePartHeader } from '@/components/ThreePartHeader/ThreePartHeader';
 import { usePropertyOwner } from '@/hooks/propertyOwner';
-import { OpenInNewIcon } from '@/icons/icons';
 import { NavigationType } from '@/types/enums';
 import { Uri } from '@/types/types';
 import { displayName, isRenderable } from '@/util/propertyTreeHelpers';
-import { useWindowLayoutProvider } from '@/windowmanagement/WindowLayout/hooks';
 
+import { OpenInNewWindowButton } from './OpenInNewWindowButton';
 import { SceneGraphNodeMoreMenu } from './SceneGraphNodeMoreMenu';
-import { SceneGraphNodeView } from './SceneGraphNodeView';
 
 interface Props {
   uri: Uri;
   onClick?: () => void;
   label?: string;
+  showOpenInNewWindow?: boolean;
 }
 
-export function SceneGraphNodeHeader({ uri, onClick, label }: Props) {
+export function SceneGraphNodeHeader({
+  uri,
+  onClick,
+  label,
+  showOpenInNewWindow = true
+}: Props) {
   const propertyOwner = usePropertyOwner(uri);
-  const { addWindow } = useWindowLayoutProvider();
 
   const renderableUri = propertyOwner?.subowners.find((uri) => isRenderable(uri));
   const hasRenderable = renderableUri !== undefined;
 
   if (!propertyOwner) {
     return <></>;
-  }
-
-  function openInNewWindow() {
-    addWindow(<SceneGraphNodeView uri={uri} />, {
-      id: 'sgn-' + uri,
-      title: name,
-      position: 'float'
-    });
   }
 
   const name = label ?? displayName(propertyOwner);
@@ -77,9 +72,7 @@ export function SceneGraphNodeHeader({ uri, onClick, label }: Props) {
             variant={'subtle'}
             identifier={propertyOwner.identifier}
           />
-          <ActionIcon onClick={openInNewWindow} size={'sm'} flex={0}>
-            <OpenInNewIcon />
-          </ActionIcon>
+          {showOpenInNewWindow && <OpenInNewWindowButton uri={uri} />}
           <SceneGraphNodeMoreMenu uri={uri} />
         </Group>
       }

--- a/src/panels/Scene/SceneGraphNode/SceneGraphNodeHeader.tsx
+++ b/src/panels/Scene/SceneGraphNode/SceneGraphNodeHeader.tsx
@@ -8,7 +8,7 @@ import { NavigationType } from '@/types/enums';
 import { Uri } from '@/types/types';
 import { displayName, isRenderable } from '@/util/propertyTreeHelpers';
 
-import { OpenInNewWindowButton } from './OpenInNewWindowButton';
+import { OpenSgnInNewWindowButton } from './OpenSgnInNewWindowButton';
 import { SceneGraphNodeMoreMenu } from './SceneGraphNodeMoreMenu';
 
 interface Props {
@@ -72,7 +72,7 @@ export function SceneGraphNodeHeader({
             variant={'subtle'}
             identifier={propertyOwner.identifier}
           />
-          {showOpenInNewWindow && <OpenInNewWindowButton uri={uri} />}
+          {showOpenInNewWindow && <OpenSgnInNewWindowButton uri={uri} />}
           <SceneGraphNodeMoreMenu uri={uri} />
         </Group>
       }

--- a/src/panels/Scene/SceneGraphNode/SceneGraphNodeView.tsx
+++ b/src/panels/Scene/SceneGraphNode/SceneGraphNodeView.tsx
@@ -61,7 +61,14 @@ export function SceneGraphNodeView({
   return (
     <Layout>
       <Layout.FixedSection>
-        <Group gap={'xs'} py={'xs'} pl={'xs'} grow preventGrowOverflow={false}>
+        <Group
+          gap={'xs'}
+          py={'xs'}
+          pl={'xs'}
+          grow
+          preventGrowOverflow={false}
+          wrap={'nowrap'}
+        >
           {/* The key here is necessary to make sure that the component is re-rendered
           when the anchor node changes, to trigger the animation */}
           <Box key={uri} className={styles.highlight}>

--- a/src/panels/Scene/SceneGraphNode/SceneGraphNodeView.tsx
+++ b/src/panels/Scene/SceneGraphNode/SceneGraphNodeView.tsx
@@ -63,7 +63,7 @@ export function SceneGraphNodeView({
       <Layout.FixedSection>
         <Group
           gap={'xs'}
-          py={'xs'}
+          pb={'xs'}
           pl={'xs'}
           grow
           preventGrowOverflow={false}

--- a/src/panels/Scene/SceneGraphNode/SceneGraphNodeView.tsx
+++ b/src/panels/Scene/SceneGraphNode/SceneGraphNodeView.tsx
@@ -1,12 +1,10 @@
-import { Box, CloseButton, Group, Tabs, Text, Tooltip } from '@mantine/core';
+import { Box, Group, Tabs, Text, Tooltip } from '@mantine/core';
 
 import { Layout } from '@/components/Layout/Layout';
 import { PropertyOwner } from '@/components/PropertyOwner/PropertyOwner';
 import { PropertyOwnerContent } from '@/components/PropertyOwner/PropertyOwnerContent';
 import { ScrollBox } from '@/components/ScrollBox/ScrollBox';
 import { usePropertyOwner, useVisibleProperties } from '@/hooks/propertyOwner';
-import { useAppDispatch } from '@/redux/hooks';
-import { setSceneTreeSelectedNode } from '@/redux/local/localSlice';
 import { Uri } from '@/types/types';
 import { isRenderable, isSgnTransform } from '@/util/propertyTreeHelpers';
 
@@ -17,15 +15,20 @@ import styles from './SceneGraphNodeView.module.css';
 
 interface Props {
   uri: Uri;
-  closeable?: boolean;
+  // Extra content to be shown at the top right of the view
+  extraTopControls?: React.ReactNode;
+  showOpenInNewWindow?: boolean;
 }
 
-export function SceneGraphNodeView({ uri, closeable = false }: Props) {
+export function SceneGraphNodeView({
+  uri,
+  extraTopControls,
+  showOpenInNewWindow
+}: Props) {
   const propertyOwner = usePropertyOwner(uri);
 
   // The SGN properties that are visible under the current user level setting
   const visibleProperties = useVisibleProperties(propertyOwner);
-  const dispatch = useAppDispatch();
 
   if (!propertyOwner) {
     return (
@@ -58,18 +61,13 @@ export function SceneGraphNodeView({ uri, closeable = false }: Props) {
   return (
     <Layout>
       <Layout.FixedSection>
-        <Group gap={5} py={'xs'} pl={'xs'} grow preventGrowOverflow={false}>
-          {/* // The key here is necessary to make sure that the component is re-rendered when the
-        // anchor node changes, to trigger the animation */}
+        <Group gap={'xs'} py={'xs'} pl={'xs'} grow preventGrowOverflow={false}>
+          {/* The key here is necessary to make sure that the component is re-rendered
+          when the anchor node changes, to trigger the animation */}
           <Box key={uri} className={styles.highlight}>
-            <SceneGraphNodeHeader uri={uri} />
+            <SceneGraphNodeHeader uri={uri} showOpenInNewWindow={showOpenInNewWindow} />
           </Box>
-          {closeable && (
-            <CloseButton
-              flex={0}
-              onClick={() => dispatch(setSceneTreeSelectedNode(null))}
-            />
-          )}
+          {extraTopControls}
         </Group>
       </Layout.FixedSection>
       <Layout.GrowingSection>

--- a/src/panels/Scene/SceneGraphNode/SceneGraphNodeView.tsx
+++ b/src/panels/Scene/SceneGraphNode/SceneGraphNodeView.tsx
@@ -23,7 +23,7 @@ interface Props {
 export function SceneGraphNodeView({
   uri,
   extraTopControls,
-  showOpenInNewWindow
+  showOpenInNewWindow = true
 }: Props) {
   const propertyOwner = usePropertyOwner(uri);
 

--- a/src/panels/Scene/ScenePanel.tsx
+++ b/src/panels/Scene/ScenePanel.tsx
@@ -34,7 +34,6 @@ export function ScenePanel() {
                 onClick={() => dispatch(setSceneTreeSelectedNode(null))}
               />
             }
-            showOpenInNewWindow
           />
         </Layout.GrowingSection>
       </Layout>

--- a/src/panels/Scene/ScenePanel.tsx
+++ b/src/panels/Scene/ScenePanel.tsx
@@ -1,6 +1,9 @@
+import { CloseButton } from '@mantine/core';
+
 import { Layout } from '@/components/Layout/Layout';
 import { ResizeableContent } from '@/components/ResizeableContent/ResizeableContent';
-import { useAppSelector } from '@/redux/hooks';
+import { useAppDispatch, useAppSelector } from '@/redux/hooks';
+import { setSceneTreeSelectedNode } from '@/redux/local/localSlice';
 import { useWindowSize } from '@/windowmanagement/Window/hooks';
 
 import { SceneGraphNodeView } from './SceneGraphNode/SceneGraphNodeView';
@@ -12,6 +15,8 @@ export function ScenePanel() {
     (state) => state.local.sceneTree.currentlySelectedNode
   );
 
+  const dispatch = useAppDispatch();
+
   if (currentlySelectedNode) {
     return (
       <Layout>
@@ -21,7 +26,16 @@ export function ScenePanel() {
           </ResizeableContent>
         </Layout.FixedSection>
         <Layout.GrowingSection>
-          <SceneGraphNodeView uri={currentlySelectedNode} closeable />
+          <SceneGraphNodeView
+            uri={currentlySelectedNode}
+            extraTopControls={
+              <CloseButton
+                flex={0}
+                onClick={() => dispatch(setSceneTreeSelectedNode(null))}
+              />
+            }
+            showOpenInNewWindow
+          />
         </Layout.GrowingSection>
       </Layout>
     );


### PR DESCRIPTION
Small suggestion to merge into the branch for this PR: https://github.com/OpenSpace/OpenSpace-WebGui/pull/100

Addresses some things that I did not know how to comment on: 
1. `SceneGraphNodeView` should not have to know about the currently selected node - IMO.  Open to discussion here, if adding back the "closable" variable is preferable to you
2. Tighten up the UI a bit - i.e. remove some padding
3. Make a separate component for the button that opens a SGN in another window
4. Do not show this button in a popped out window

ONly for @ylvaselling. @engbergandreas you can ignore this one :) 