### PR TITLE
Fix getting started guide buttons that broke in recent rewrite

### DIFF
--- a/src/panels/GettingStartedPanel/Steps/ContentSteps.tsx
+++ b/src/panels/GettingStartedPanel/Steps/ContentSteps.tsx
@@ -11,6 +11,7 @@ import {
 
 import { FolderPath } from '@/components/FolderPath/FolderPath';
 import { FocusIcon, SceneIcon } from '@/icons/icons';
+import { TaskBarMenuButton } from '@/panels/Menu/TaskBar/TaskBarMenuButton';
 import { SceneGraphNodeHeader } from '@/panels/Scene/SceneGraphNode/SceneGraphNodeHeader';
 import { IconSize } from '@/types/enums';
 
@@ -29,9 +30,9 @@ export const ContentSteps = [
   <Stack gap={'md'}>
     <Group>
       <Text>All the content in OpenSpace can be found in the Scene menu:</Text>
-      <Group>
-        <SceneIcon size={IconSize.lg} /> Scene
-      </Group>
+      <TaskBarMenuButton id={''} leftSection={<SceneIcon size={IconSize.lg} />}>
+        Scene
+      </TaskBarMenuButton>
     </Group>
     <Text>
       You can search for objects in the top search bar. The results are going to look like

--- a/src/panels/GettingStartedPanel/Steps/NavigationSteps.tsx
+++ b/src/panels/GettingStartedPanel/Steps/NavigationSteps.tsx
@@ -76,7 +76,7 @@ export const NavigationSteps: React.JSX.Element[] = [
     <Text>
       Open the navigation menu and click on the "Focus" button to focus on the Moon. The
       navigation menu can be found in the bottom bar:
-      <OriginPanelMenuButton onClick={() => {}} />
+      <OriginPanelMenuButton id={''} />
     </Text>
   </>,
   <>

--- a/src/panels/GettingStartedPanel/Steps/TimeSteps.tsx
+++ b/src/panels/GettingStartedPanel/Steps/TimeSteps.tsx
@@ -40,7 +40,7 @@ export const TimeSteps = [
     <ChangeYearTask />
     <Text>To open the Time Panel, click on the following icon in the taskbar:</Text>
     <Box my={'xs'}>
-      <TimePanelMenuButton onClick={() => {}} />
+      <TimePanelMenuButton id={''} />
     </Box>
     <Group>
       <Text>Change the year by changing the value of the year in the time input:</Text>

--- a/src/panels/Menu/TaskBar/TaskBarMenuButton.tsx
+++ b/src/panels/Menu/TaskBar/TaskBarMenuButton.tsx
@@ -14,7 +14,21 @@ export function TaskBarMenuButton({ id, children, ...props }: Props) {
   );
   const { addWindow, closeWindow } = useWindowLayoutProvider();
 
+  if (id === '') {
+    // This is a special case used to show the buttons in the getting started guide.
+    // These buttons should not be clickable
+    return (
+      <Button px={'sm'} size={'lg'} {...props} style={{ pointerEvents: 'none' }}>
+        {children}
+      </Button>
+    );
+  }
+
   const item = menuItemsData[id];
+
+  if (!item) {
+    throw new Error(`No menu item found for id: ${id}`);
+  }
 
   function onClick(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
     if (event.shiftKey) {
@@ -41,7 +55,7 @@ export function TaskBarMenuButton({ id, children, ...props }: Props) {
       onContextMenu={onRightClick}
       size={'xl'}
       variant={'menubar'}
-      aria-label={item.title}
+      aria-label={item?.title}
       style={{
         borderBottom: itemConfig?.isOpen ? 'var(--openspace-border-active)' : '',
         borderRadius: 0

--- a/src/panels/Menu/TaskBar/TaskBarMenuButton.tsx
+++ b/src/panels/Menu/TaskBar/TaskBarMenuButton.tsx
@@ -27,7 +27,7 @@ export function TaskBarMenuButton({ id, children, ...props }: Props) {
   const item = menuItemsData[id];
 
   if (!item) {
-    throw new Error(`No menu item found for id: ${id}`);
+    throw new Error(`No menu item found for id: '${id}'`);
   }
 
   function onClick(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
@@ -55,7 +55,7 @@ export function TaskBarMenuButton({ id, children, ...props }: Props) {
       onContextMenu={onRightClick}
       size={'xl'}
       variant={'menubar'}
-      aria-label={item?.title}
+      aria-label={item.title}
       style={{
         borderBottom: itemConfig?.isOpen ? 'var(--openspace-border-active)' : '',
         borderRadius: 0


### PR DESCRIPTION
Unfortunately, the solution we had for showing the taskbar buttons broke in the recent rewrite. This fixes them, and also makes the button unclickable

I made what I found to be the easiest solution, which is to just send in an empty string for the `id`. This felt more intentional than e.g. not specifying the `id` at all and led to minimal code changes. 

Let me know what you think. This should get in before the user test

