### PR TITLE
Only show focus style on keyboard navigation

### DIFF
--- a/src/theme/mantineTheme.module.css
+++ b/src/theme/mantineTheme.module.css
@@ -1,4 +1,4 @@
-.focus:focus {
+.focus:focus-visible {
   outline-offset: -2px;
   outline: 2px solid var(--mantine-color-text);
 }


### PR DESCRIPTION
I don't know about you, but I found it a bit annoying that the focus style is visible even on mouse click (it clutters the view unnecessarily, IMO). This changes so it is only visible when using keyboard navigation. 

However, if you prefer to always have it on, this PR can be closed. Wanted to suggest it at least

Source: 
https://mantine.dev/theming/theme-object/#focusclassname