### PR TITLE
Add package with types for the experimental file I/O features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@types/d3": "^7.4.3",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
+        "@types/wicg-file-system-access": "^2023.10.5",
         "@vitejs/plugin-react": "^4.3.1",
         "eslint": "^9.9.0",
         "eslint-config-prettier": "^10.0.1",
@@ -1876,6 +1877,13 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/wicg-file-system-access": {
+      "version": "2023.10.5",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2023.10.5.tgz",
+      "integrity": "sha512-e9kZO9kCdLqT2h9Tw38oGv9UNzBBWaR1MzuAavxPcsV/7FJ3tWbU6RI3uB+yKIDPGLkGVbplS52ub0AcRLvrhA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6591,10 +6591,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.0.tgz",
-      "integrity": "sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "postcss": "^8.5.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/d3": "^7.4.3",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
+    "@types/wicg-file-system-access": "^2023.10.5",
     "@vitejs/plugin-react": "^4.3.1",
     "eslint": "^9.9.0",
     "eslint-config-prettier": "^10.0.1",

--- a/src/util/fileIOhooks.ts
+++ b/src/util/fileIOhooks.ts
@@ -36,7 +36,7 @@ async function openSaveFileDialog(contents: JSON) {
 
   const supportsSaveDialog = 'showSaveFilePicker' in self;
   if (supportsSaveDialog) {
-    const options = {
+    const options: SaveFilePickerOptions = {
       types: [
         {
           description: 'Text Files',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strict": true,
-    "typeRoots": ["./src/types/*.d.ts"]
+    "typeRoots": ["./src/types/*.d.ts", "./node_modules/@types"],
   },
   "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Had to be fixed to create a `build` version of the page. 

Uses [this package](https://www.npmjs.com/package/@types/wicg-file-system-access), which seems to be the recommended way to deal with this.  Sources: 
https://issues.chromium.org/issues/40244598#comment2
https://stackoverflow.com/questions/71309058/property-showsavefilepicker-does-not-exist-on-type-window-typeof-globalthis

Note that this PR is based on master, which as time of creation has a couple of other issues that prevent building until #111 is merged. Tested it in the `feature/user-test-2` branch