### PR TITLE
Use markedNodes data from profile topic to populate featured nodes lists

### DIFF
--- a/src/panels/OriginPanel/OriginPanel.tsx
+++ b/src/panels/OriginPanel/OriginPanel.tsx
@@ -6,9 +6,10 @@ import { Layout } from '@/components/Layout/Layout';
 import { AnchorIcon, FocusIcon, TelescopeIcon } from '@/icons/icons';
 import { useAppSelector } from '@/redux/hooks';
 import { EngineMode, IconSize } from '@/types/enums';
-import { Uri } from '@/types/types';
+import {  Uri } from '@/types/types';
 import { NavigationAimKey, NavigationAnchorKey } from '@/util/keys';
-import { hasInterestingTag, isPropertyOwnerHidden } from '@/util/propertyTreeHelpers';
+import { isPropertyOwnerHidden } from '@/util/propertyTreeHelpers';
+import { useFeaturedNodes } from '@/util/propertyTreeHooks';
 
 import { AnchorAimView } from './AnchorAimView/AnchorAimView';
 import { FocusView } from './FocusView/FocusView';
@@ -24,6 +25,8 @@ export function OriginPanel() {
   const properties = useAppSelector((state) => state.properties.properties);
   const engineMode = useAppSelector((state) => state.engineMode.mode);
 
+  const featuredNodes = useFeaturedNodes();
+
   const shouldStartInAnchorAim = useAppSelector((state) => {
     const aimProp = state.properties.properties[NavigationAimKey];
     const anchorProp = state.properties.properties[NavigationAnchorKey];
@@ -33,17 +36,6 @@ export function OriginPanel() {
     shouldStartInAnchorAim ? NavigationMode.AnchorAim : NavigationMode.Focus
   );
 
-  const sortedDefaultList = useMemo(() => {
-    const uris: Uri[] = propertyOwners.Scene?.subowners ?? [];
-    const markedInterestingNodeUris = uris.filter((uri) =>
-      hasInterestingTag(uri, propertyOwners)
-    );
-    const favorites = markedInterestingNodeUris
-      .map((uri) => propertyOwners[uri])
-      .filter((po) => po !== undefined);
-    return favorites.slice().sort((a, b) => a.name.localeCompare(b.name));
-  }, [propertyOwners]);
-
   // @TODO (2025-02-24, emmbr): Remove dependency on properties object
   const sortedSearchableNodes = useMemo(() => {
     const uris: Uri[] = propertyOwners.Scene?.subowners ?? [];
@@ -52,9 +44,9 @@ export function OriginPanel() {
       .filter((po) => po !== undefined);
 
     // Searchable nodes are all nodes that are not hidden in the GUI
-    const searchableNodes = allNodes.filter((node) => {
-      return !isPropertyOwnerHidden(node.uri, properties);
-    });
+    const searchableNodes = allNodes.filter((node) =>
+      !isPropertyOwnerHidden(node.uri, properties)
+    );
 
     return searchableNodes.slice().sort((a, b) => a.name.localeCompare(b.name));
   }, [properties, propertyOwners]);
@@ -108,14 +100,14 @@ export function OriginPanel() {
       <Layout.GrowingSection>
         {navigationMode === NavigationMode.Focus && (
           <FocusView
-            favorites={sortedDefaultList}
+            favorites={featuredNodes}
             searchableNodes={sortedSearchableNodes}
             matcherFunction={searchMatcherFunction}
           />
         )}
         {navigationMode === NavigationMode.AnchorAim && (
           <AnchorAimView
-            favorites={sortedDefaultList}
+            favorites={featuredNodes}
             searchableNodes={sortedSearchableNodes}
             matcherFunction={searchMatcherFunction}
           />

--- a/src/panels/Scene/SceneTree/FeaturedSceneTree.tsx
+++ b/src/panels/Scene/SceneTree/FeaturedSceneTree.tsx
@@ -3,7 +3,7 @@ import { Tree } from '@mantine/core';
 import {
   useAimNode,
   useAnchorNode,
-  useInterestingTagOwners
+  useFeaturedNodes
 } from '@/util/propertyTreeHooks';
 
 import { SceneTreeNode } from './SceneTreeNode';
@@ -15,7 +15,7 @@ import { SceneTreeNodeData } from './types';
  * nodes marked as interesting.
  */
 export function FeaturedSceneTree() {
-  const interestingOwners = useInterestingTagOwners();
+  const featuredNodes = useFeaturedNodes();
   const anchorNode = useAnchorNode();
   const aimNode = useAimNode();
 
@@ -33,11 +33,11 @@ export function FeaturedSceneTree() {
     featuredTreeData.push(aimData);
   }
 
-  if (interestingOwners.length > 0) {
+  if (featuredNodes.length > 0) {
     featuredTreeData.push({
       label: 'Quick Access',
       value: SceneTreeGroupPrefixKey + 'interesting',
-      children: interestingOwners.map((owner) =>
+      children: featuredNodes.map((owner) =>
         treeDataForSceneGraphNode(owner.name, owner.uri)
       )
     });

--- a/src/redux/profile/profileMiddleware.ts
+++ b/src/redux/profile/profileMiddleware.ts
@@ -6,14 +6,7 @@ import { AppStartListening } from '@/redux/listenerMiddleware';
 
 import { setMenuItemVisible } from '../local/localSlice';
 
-export interface ProfileState {
-  uiPanelVisibility: {
-    // The key here should match the id of the menu item,
-    // else will be ignored
-    [key: string]: boolean;
-  };
-  markNodes: string[];
-}
+import { ProfileState, setMarkedNodes } from './profileSlice';
 
 export const getProfile = createAsyncThunk('profile/getProfile', async () => {
   const topic = api.startTopic('profile', {});
@@ -33,10 +26,15 @@ export const addProfileListener = (startListening: AppStartListening) => {
   startListening({
     actionCreator: getProfile.fulfilled,
     effect: async (action, listenerApi) => {
+      // Get the data from the profile topic and set it in the redux store
+
+      // Panel visibility settings
       Object.entries(action.payload.uiPanelVisibility).forEach(([key, value]) => {
         listenerApi.dispatch(setMenuItemVisible({ id: key, visible: value }));
       });
-      // @TODO (ylvse 2025-03-15): handle marknodes
+
+      // Marked nodes
+      listenerApi.dispatch(setMarkedNodes(action.payload.markNodes));
     }
   });
 };

--- a/src/redux/profile/profileSlice.ts
+++ b/src/redux/profile/profileSlice.ts
@@ -1,0 +1,32 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { Identifier } from '@/types/types';
+
+export interface ProfileState {
+  uiPanelVisibility: {
+    // The key here should match the id of the menu item,
+    // else will be ignored
+    [key: string]: boolean;
+  };
+  markNodes: Identifier[];
+}
+
+const initialState: ProfileState = {
+  uiPanelVisibility: {},
+  markNodes: []
+};
+
+export const profileSlice = createSlice({
+  name: 'profile',
+  initialState,
+  reducers: {
+    setMarkedNodes: (state, action: PayloadAction<Identifier[]>) => {
+      state.markNodes = action.payload;
+      return state;
+    },
+  }
+});
+
+// Action creators are generated for each case reducer function, replaces the `Actions/index.js`
+export const { setMarkedNodes } = profileSlice.actions;
+export const profileReducer = profileSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -11,6 +11,7 @@ import { flightControllerReducer } from './flightcontroller/flightControllerSlic
 import { groupsReducer } from './groups/groupsSlice';
 import { localReducer } from './local/localSlice';
 import { missionsReducer } from './missions/missionsSlice';
+import { profileReducer } from './profile/profileSlice';
 import { propertiesReducer } from './propertytree/properties/propertiesSlice';
 import { propertyOwnersReducer } from './propertytree/propertyowner/propertyOwnerSlice';
 import { sessionRecordingReducer } from './sessionrecording/sessionRecordingSlice';
@@ -33,6 +34,7 @@ export const store = configureStore({
     groups: groupsReducer,
     local: localReducer,
     missions: missionsReducer,
+    profile: profileReducer,
     properties: propertiesReducer,
     propertyOwners: propertyOwnersReducer,
     sessionRecording: sessionRecordingReducer,

--- a/src/util/keys.ts
+++ b/src/util/keys.ts
@@ -17,7 +17,9 @@ export const JumpToFadeDurationKey = 'NavigationHandler.JumpToFadeDuration';
 // To get any scene graph node you need ScenePrefix+NodeIdentifier
 export const ScenePrefixKey = 'Scene.';
 
-export const InterestingTagKey = 'GUI.Interesting';
+// @TODO (2024-02-24, emmbr): Remove this key here and from engine - it is no longer used
+// export const InterestingTagKey = 'GUI.Interesting';
+
 export const rootOwnerKey = '__rootOwner';
 export const GeoLocationGroupKey = '/GeoLocation';
 

--- a/src/util/propertyTreeHelpers.ts
+++ b/src/util/propertyTreeHelpers.ts
@@ -9,7 +9,7 @@ import {
   Uri
 } from '@/types/types';
 
-import { InterestingTagKey, ScenePrefixKey } from './keys';
+import { ScenePrefixKey } from './keys';
 
 // TODO: Maybe move some of these to a "uriHelpers" file?
 export function identifierFromUri(uri: Uri): Identifier {
@@ -53,13 +53,6 @@ export function sgnUri(identifier: Identifier | undefined): Uri {
 export function removeLastWordFromUri(uri: Uri): Uri {
   const index = uri.lastIndexOf('.');
   return index === -1 ? uri : uri.substring(0, index);
-}
-
-export function hasInterestingTag(
-  uri: Uri,
-  propertyOwners: PropertyOwners
-): boolean | undefined {
-  return propertyOwners[uri]?.tags.some((tag) => tag.includes(InterestingTagKey));
 }
 
 export function guiOrderingNumber(uri: Uri, properties: Properties): number | undefined {

--- a/src/util/propertyTreeHooks.ts
+++ b/src/util/propertyTreeHooks.ts
@@ -2,26 +2,24 @@ import { useMemo } from 'react';
 
 import { useStringProperty } from '@/hooks/properties';
 import { useAppSelector } from '@/redux/hooks';
-import { Uri } from '@/types/types';
+import { PropertyOwner } from '@/types/types';
 
 import { NavigationAimKey, NavigationAnchorKey } from './keys';
-import { hasInterestingTag, sgnUri } from './propertyTreeHelpers';
+import { sgnUri } from './propertyTreeHelpers';
 
-export function useInterestingTagOwners() {
+/**
+ * Get all the nodes marked in the profile, as a memo:d list of property owners.
+ */
+export function useFeaturedNodes() : PropertyOwner[] {
   const propertyOwners = useAppSelector((state) => state.propertyOwners.propertyOwners);
+  const markedNodes = useAppSelector((state) => state.profile.markNodes);
 
-  const sortedDefaultList = useMemo(() => {
-    const uris: Uri[] = propertyOwners.Scene?.subowners ?? [];
-    const markedInterestingNodeUris = uris.filter((uri) =>
-      hasInterestingTag(uri, propertyOwners)
-    );
-    const favorites = markedInterestingNodeUris
-      .map((uri) => propertyOwners[uri])
-      .filter((po) => po !== undefined);
-    return favorites.slice().sort((a, b) => a.name.localeCompare(b.name));
-  }, [propertyOwners]);
-
-  return sortedDefaultList;
+  return useMemo(
+    () => markedNodes.map(
+      (id) => propertyOwners[sgnUri(id)]).filter((po) => po !== undefined
+    ),
+    [markedNodes, propertyOwners]
+  );
 }
 
 export function useAnchorNode() {


### PR DESCRIPTION
The order in both the Scene panel and the navigation menu now match the one specified in the profile. e.g. Default profile: 

![image](https://github.com/user-attachments/assets/29d74663-0f2d-4dd5-b752-5fd9e7dc57b1)

https://github.com/OpenSpace/OpenSpace/issues/3454