### PR TITLE
Add aria-label to all action icons

### DIFF
--- a/src/components/Collapsable/CollapsableHeader/CollapsableHeader.tsx
+++ b/src/components/Collapsable/CollapsableHeader/CollapsableHeader.tsx
@@ -24,7 +24,11 @@ export function CollapsableHeader({
 }: Props) {
   return (
     <Group wrap={'nowrap'} gap={0} className={classes.header} {...styleProps}>
-      <ActionIcon variant={'transparent'} onClick={toggle}>
+      <ActionIcon
+        variant={'transparent'}
+        onClick={toggle}
+        aria-label={`${expanded ? 'expand' : 'close'} ${title}`}
+      >
         {expanded ? (
           <ChevronDownIcon size={IconSize.xs} />
         ) : (

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -15,7 +15,12 @@ export function ColorPicker({ color, disabled, onChange, withAlpha }: Props) {
   return (
     <Popover position={'right-end'} withArrow arrowPosition={'center'}>
       <Popover.Target>
-        <ActionIcon disabled={disabled} size={'lg'} variant={'subtle'}>
+        <ActionIcon
+          disabled={disabled}
+          size={'lg'}
+          variant={'subtle'}
+          aria-label={'@TODO'}
+        >
           <ColorSwatch color={rgbaToColor(color, withAlpha)} />
         </ActionIcon>
       </Popover.Target>

--- a/src/components/CopyToClipboardButton/CopyToClipboardButton.tsx
+++ b/src/components/CopyToClipboardButton/CopyToClipboardButton.tsx
@@ -16,6 +16,7 @@ export function CopyToClipboardButton({ value }: Props) {
             size={'sm'}
             variant={'subtle'}
             onClick={copy}
+            aria-label={'Copy to clipboard'}
           >
             <CopyIcon />
           </ActionIcon>

--- a/src/components/DragReorderList/DragReorderList.tsx
+++ b/src/components/DragReorderList/DragReorderList.tsx
@@ -68,7 +68,11 @@ export function DragReorderList<T>({
                     {dragHandlePosition === 'right' && (
                       <Box flex={1}>{renderFunc(element, i)}</Box>
                     )}
-                    <ActionIcon style={{ cursor: 'grab' }} {...item.dragHandleProps}>
+                    <ActionIcon
+                      style={{ cursor: 'grab' }}
+                      {...item.dragHandleProps}
+                      aria-label={'Move item up or down (keyboard control not suppored)'}
+                    >
                       <DragHandleIcon />
                     </ActionIcon>
                     {dragHandlePosition === 'left' && (

--- a/src/components/FilterList/FilterListInputField.tsx
+++ b/src/components/FilterList/FilterListInputField.tsx
@@ -21,6 +21,7 @@ function InputButton({ showMoreButton }: InputButtonProps) {
         variant={'subtle'}
         color={'gray'}
         onClick={() => setSearchString('')}
+        aria-label={'Clear search input'}
       >
         <CancelIcon />
       </ActionIcon>

--- a/src/components/Input/NumericInput/StepControlButton.tsx
+++ b/src/components/Input/NumericInput/StepControlButton.tsx
@@ -89,6 +89,7 @@ export function StepControlButton({
       size={'xs'}
       variant={'transparent'}
       tabIndex={tabIndex}
+      aria-label={direction === 'up' ? 'Increment value' : 'Decrement value'}
       {...props}
     >
       {direction === 'up' ? <ChevronUpIcon /> : <ChevronDownIcon />}

--- a/src/components/NodeNavigationButton/NodeNavigationButton.tsx
+++ b/src/components/NodeNavigationButton/NodeNavigationButton.tsx
@@ -230,6 +230,7 @@ export function NodeNavigationButton({
           variant={variant}
           style={style}
           disabled={disabled}
+          aria-label={content.title}
         >
           {content.icon}
         </ActionIcon>

--- a/src/components/ResizeableContent/ResizeableContent.tsx
+++ b/src/components/ResizeableContent/ResizeableContent.tsx
@@ -127,6 +127,7 @@ export function ResizeableContent({
           }}
           size={'xs'}
           radius={0}
+          aria-label={'Resize window (keyboard control not suppored)'}
         >
           <DragHandleIcon size={IconSize.xs} />
         </ActionIcon>

--- a/src/components/SettingsPopout/SettingsPopout.tsx
+++ b/src/components/SettingsPopout/SettingsPopout.tsx
@@ -12,7 +12,7 @@ export function SettingsPopout({ popoverWidth, title, children, ...styleProps }:
   return (
     <Menu position={'right-start'} closeOnItemClick={false} width={popoverWidth}>
       <Menu.Target>
-        <ActionIcon {...styleProps}>
+        <ActionIcon {...styleProps} aria-label={'Open settings'}>
           <SettingsIcon />
         </ActionIcon>
       </Menu.Target>

--- a/src/panels/ExoplanetsPanel/ExoplanetEntry.tsx
+++ b/src/panels/ExoplanetsPanel/ExoplanetEntry.tsx
@@ -19,6 +19,7 @@ export function ExoplanetEntry({ name, isAdded, onClick }: ExoplanetProps) {
           style={{ flexGrow: 0 }}
           onClick={onClick}
           color={isAdded ? 'red' : 'blue'}
+          aria-label={`${isAdded ? 'Remove' : 'Add'} system: ${name}`}
         >
           {isAdded ? <MinusIcon /> : <PlusIcon />}
         </ActionIcon>

--- a/src/panels/GeoLocationPanel/AnchorPanels/EarthPanel/AddedCustomNodes.tsx
+++ b/src/panels/GeoLocationPanel/AnchorPanels/EarthPanel/AddedCustomNodes.tsx
@@ -23,6 +23,7 @@ export function AddedCustomNodes({ addedNodes, removeFocusNode }: Props) {
             color={'red'}
             flex={0}
             onClick={() => removeFocusNode(identifier)}
+            aria-label={`Remove node ${identifier}`}
           >
             <MinusIcon />
           </ActionIcon>

--- a/src/panels/GeoLocationPanel/AnchorPanels/EarthPanel/EarthEntry.tsx
+++ b/src/panels/GeoLocationPanel/AnchorPanels/EarthPanel/EarthEntry.tsx
@@ -81,7 +81,8 @@ export function EarthEntry({
               ? removeFocusNode(addressUtf8)
               : addFocusNode(addressUtf8, lat, long, alt)
           }
-          color={isAdded ? 'red' : 'blue'}
+          color={isAdded ? 'red' : 'blue'} // @TODO anden88 2025-04-14: do we want this color? It is currently not showing due to the chosen variant.
+          aria-label={`${isAdded ? 'Remove' : 'Add'} node: ${address}`}
         >
           {isAdded ? <MinusIcon /> : <PlusIcon />}
         </ActionIcon>

--- a/src/panels/GettingStartedPanel/Steps/ContentSteps.tsx
+++ b/src/panels/GettingStartedPanel/Steps/ContentSteps.tsx
@@ -52,7 +52,12 @@ export const ContentSteps = [
     </ClickBlocker>
     <Group>
       <Text>You can focus on objects by clicking the focus icon: </Text>
-      <ActionIcon size={'sm'} style={{ pointerEvents: 'none' }}>
+      <ActionIcon
+        size={'sm'}
+        style={{ pointerEvents: 'none' }}
+        aria-label={'Focus object'}
+        aria-disabled
+      >
         <FocusIcon size={IconSize.xs} />
       </ActionIcon>
     </Group>

--- a/src/panels/GettingStartedPanel/Steps/TimeSteps.tsx
+++ b/src/panels/GettingStartedPanel/Steps/TimeSteps.tsx
@@ -76,10 +76,20 @@ export const TimeSteps = [
     <Text>In the Time Panel:</Text>
     <Group>
       <Text>Click on the buttons that adjust the delta time:</Text>
-      <ActionIcon size={'lg'} style={{ pointerEvents: 'none' }}>
+      <ActionIcon
+        size={'lg'}
+        style={{ pointerEvents: 'none' }}
+        aria-label={'Rewind delta time'}
+        aria-disabled
+      >
         <FastRewindIcon size={IconSize.md} />
       </ActionIcon>
-      <ActionIcon size={'lg'} style={{ pointerEvents: 'none' }}>
+      <ActionIcon
+        size={'lg'}
+        style={{ pointerEvents: 'none' }}
+        aria-label={'Forward delta time'}
+        aria-disabled
+      >
         <FastForwardIcon size={IconSize.md} />
       </ActionIcon>
     </Group>
@@ -92,7 +102,12 @@ export const TimeSteps = [
     <PauseTimeTask />
     <Text>
       In the time panel, click on the pause icon:{' '}
-      <ActionIcon size={IconSize.lg} style={{ pointerEvents: 'none' }}>
+      <ActionIcon
+        size={IconSize.lg}
+        style={{ pointerEvents: 'none' }}
+        aria-label={'Pause time'}
+        aria-disabled
+      >
         <PauseIcon />
       </ActionIcon>{' '}
       to pause time.

--- a/src/panels/OriginPanel/AnchorAimView/AnchorAimListEntry.tsx
+++ b/src/panels/OriginPanel/AnchorAimView/AnchorAimListEntry.tsx
@@ -34,7 +34,7 @@ export function AnchorAimListEntry({
       </Text>
       <Tooltip label={'Set and target anchor'} openDelay={600}>
         <ActionIcon
-          aria-label={'Set anchor'}
+          aria-label={`Set anchor to ${node.name}`}
           size={'lg'}
           variant={isCurrentAnchor ? 'filled' : 'default'}
           onClick={(event) => onSelectAnchor(node.identifier, event)}
@@ -45,7 +45,7 @@ export function AnchorAimListEntry({
       </Tooltip>
       <Tooltip label={'Set and target aim'} openDelay={600}>
         <ActionIcon
-          aria-label={'Set aim'}
+          aria-label={`Set aim to ${node.name}`}
           size={'lg'}
           variant={isCurrentAim ? 'filled' : 'default'}
           onClick={(event) => onSelectAim(node.identifier, event)}

--- a/src/panels/Scene/SceneGraphNode/SceneGraphNodeMoreMenu.tsx
+++ b/src/panels/Scene/SceneGraphNode/SceneGraphNodeMoreMenu.tsx
@@ -70,7 +70,7 @@ export function SceneGraphNodeMoreMenu({ uri }: Props) {
   return (
     <Menu position={'right-start'}>
       <Menu.Target>
-        <ActionIcon size={'sm'}>
+        <ActionIcon size={'sm'} aria-label={'Open node menu'}>
           <VerticalDotsIcon />
         </ActionIcon>
       </Menu.Target>

--- a/src/panels/Scene/SceneTree/SceneTree.tsx
+++ b/src/panels/Scene/SceneTree/SceneTree.tsx
@@ -77,12 +77,20 @@ export function SceneTree() {
         <Box pos={'relative'}>
           <Group gap={0} pos={'absolute'} top={0} right={0}>
             <Tooltip label={'Collapse all'} position={'top'}>
-              <ActionIcon variant={'subtle'} onClick={tree.collapseAllNodes}>
+              <ActionIcon
+                variant={'subtle'}
+                onClick={tree.collapseAllNodes}
+                aria-label={'Collapse all nodes'}
+              >
                 <ChevronsUpIcon />
               </ActionIcon>
             </Tooltip>
             <Tooltip label={'Expand all'} position={'top'}>
-              <ActionIcon variant={'subtle'} onClick={tree.expandAllNodes}>
+              <ActionIcon
+                variant={'subtle'}
+                onClick={tree.expandAllNodes}
+                aria-label={'Expand all nodes'}
+              >
                 <ChevronsDownIcon />
               </ActionIcon>
             </Tooltip>

--- a/src/panels/Scene/SceneTree/SceneTreeFilters.tsx
+++ b/src/panels/Scene/SceneTree/SceneTreeFilters.tsx
@@ -5,7 +5,8 @@ import {
   Group,
   Menu,
   MultiSelect,
-  Title
+  Title,
+  Tooltip
 } from '@mantine/core';
 
 import { InfoBox } from '@/components/InfoBox/InfoBox';
@@ -43,9 +44,11 @@ export function SceneTreeFilters({ setFilter, filter }: Props) {
       )}
       <Menu position={'right-start'} withArrow closeOnItemClick={false}>
         <Menu.Target>
-          <ActionIcon>
-            <FilterIcon />
-          </ActionIcon>
+          <Tooltip label={'Additional settings to filter search result'}>
+            <ActionIcon aria-label={'Open search filter menu'}>
+              <FilterIcon />
+            </ActionIcon>
+          </Tooltip>
         </Menu.Target>
         <Menu.Dropdown maw={'300px'}>
           <Group>

--- a/src/panels/ScreenSpaceRenderablePanel/ScreenSpaceRenderablePanel.tsx
+++ b/src/panels/ScreenSpaceRenderablePanel/ScreenSpaceRenderablePanel.tsx
@@ -102,7 +102,7 @@ export function ScreenSpaceRenderablePanel() {
               onClick={() => removeSlide(uri)}
               color={'red'}
               variant={'outline'}
-              aria-label={'Remove slide'}
+              aria-label={`Remove slide ${uri}`}
             >
               <MinusIcon />
             </ActionIcon>

--- a/src/panels/SkyBrowserPanel/BrowserTabs/AddedImageCard.tsx
+++ b/src/panels/SkyBrowserPanel/BrowserTabs/AddedImageCard.tsx
@@ -70,15 +70,21 @@ export function AddedImageCard({ image, opacity }: Props) {
             label={(value) => value.toFixed(1)}
           />
         </Stack>
-        <ActionIcon
-          color={'red'}
-          variant={'outline'}
-          onClick={() =>
-            luaApi?.skybrowser.removeSelectedImageInBrowser(selectedBrowserId, image.url)
-          }
-        >
-          <DeleteIcon />
-        </ActionIcon>
+        <Tooltip label={'Delete image'}>
+          <ActionIcon
+            color={'red'}
+            variant={'outline'}
+            onClick={() =>
+              luaApi?.skybrowser.removeSelectedImageInBrowser(
+                selectedBrowserId,
+                image.url
+              )
+            }
+            aria-label={`Remove ${image.name} image`}
+          >
+            <DeleteIcon />
+          </ActionIcon>
+        </Tooltip>
       </Group>
     </Paper>
   );

--- a/src/panels/SkyBrowserPanel/BrowserTabs/TabContent.tsx
+++ b/src/panels/SkyBrowserPanel/BrowserTabs/TabContent.tsx
@@ -77,49 +77,68 @@ export function TabContent({
       <Group justify={'space-between'}>
         <ActionIcon.Group>
           <Tooltip label={'Look at target'}>
-            <ActionIcon onClick={() => luaApi?.skybrowser.adjustCamera(browserId)}>
+            <ActionIcon
+              onClick={() => luaApi?.skybrowser.adjustCamera(browserId)}
+              aria-label={'Look at skybrowser target'}
+            >
               <EyeIcon />
             </ActionIcon>
           </Tooltip>
           <Tooltip label={'Move target to center of view'}>
             <ActionIcon
               onClick={() => luaApi?.skybrowser.centerTargetOnScreen(browserId)}
+              aria-label={'Move skybrowser target to center of view'}
             >
               <MoveTargetIcon />
             </ActionIcon>
           </Tooltip>
           <Tooltip label={'Zoom in'}>
-            <ActionIcon onClick={() => zoom(browserId, fov - zoomStep)}>
+            <ActionIcon
+              onClick={() => zoom(browserId, fov - zoomStep)}
+              aria-label={'Zoom in'}
+            >
               <ZoomInIcon />
             </ActionIcon>
           </Tooltip>
           <Tooltip label={'Zoom out'}>
-            <ActionIcon onClick={() => zoom(browserId, fov + zoomStep)}>
+            <ActionIcon
+              onClick={() => zoom(browserId, fov + zoomStep)}
+              aria-label={'Zoom out'}
+            >
               <ZoomOutIcon />
             </ActionIcon>
           </Tooltip>
           <Tooltip label={'Remove all images'}>
-            <ActionIcon onClick={removeAllImages}>
+            <ActionIcon onClick={removeAllImages} aria-label={'Remove all images'}>
               <DeleteIcon />
             </ActionIcon>
           </Tooltip>
-          <Tooltip label={'Open Telescope View'}>
-            <ActionIcon onClick={openWorldWideTelescope}>
+          <Tooltip label={'Open telescope view'}>
+            <ActionIcon
+              onClick={openWorldWideTelescope}
+              aria-label={'Open telescope view'}
+            >
               <OpenInNewIcon />
             </ActionIcon>
           </Tooltip>
         </ActionIcon.Group>
         <Group>
-          <Tooltip label={'Settings'}>
+          <Tooltip label={'Skybrowser settings'}>
             <ActionIcon
               onClick={() => setShowSettings((old) => !old)}
               variant={showSettings ? 'filled' : 'default'}
+              aria-label={`${showSettings ? 'Close' : 'Open'} skybrowser settings`}
             >
               <SettingsIcon />
             </ActionIcon>
           </Tooltip>
           <Tooltip label={'Delete browser'}>
-            <ActionIcon onClick={deleteBrowser} color={'red'} variant={'light'}>
+            <ActionIcon
+              onClick={deleteBrowser}
+              color={'red'}
+              variant={'light'}
+              aria-label={'Delete browser'}
+            >
               <CloseIcon />
             </ActionIcon>
           </Tooltip>

--- a/src/panels/SkyBrowserPanel/components/ImageInfoPopover.tsx
+++ b/src/panels/SkyBrowserPanel/components/ImageInfoPopover.tsx
@@ -8,11 +8,12 @@ interface Props {
   image: SkyBrowserImage;
 }
 
+// @TODO anden88: 2025-04-14 this should be changed to the new clickable `InfoBox`
 export function ImageInfoPopover({ image }: Props) {
   return (
     <Popover width={200} position={'bottom'} withArrow shadow={'md'} trapFocus>
       <Popover.Target>
-        <ActionIcon variant={'outline'} size={'xs'}>
+        <ActionIcon variant={'outline'} size={'xs'} aria-label={'More information'}>
           <InformationIcon />
         </ActionIcon>
       </Popover.Target>

--- a/src/panels/TimePanel/DeltaTimeStepControl.tsx
+++ b/src/panels/TimePanel/DeltaTimeStepControl.tsx
@@ -62,6 +62,7 @@ export function DeltaTimeStepsControl() {
           disabled={!hasPrevDeltaTimeStep}
           size={'lg'}
           w={'100%'}
+          aria-label={'Set previous delta time step'}
         >
           <FastRewindIcon size={IconSize.md} />
         </ActionIcon>
@@ -80,7 +81,7 @@ export function DeltaTimeStepsControl() {
       <ActionIcon
         onClick={togglePause}
         size={'lg'}
-        aria-label={isPaused ? 'play' : 'pause'}
+        aria-label={`${isPaused ? 'Play' : 'Pause'} time`}
         flex={2}
       >
         {isPaused ? <PlayIcon size={IconSize.md} /> : <PauseIcon size={IconSize.md} />}
@@ -91,6 +92,7 @@ export function DeltaTimeStepsControl() {
           disabled={!hasNextDeltaTimeStep}
           size={'lg'}
           w={'100%'}
+          aria-label={'Set next delta time step'}
         >
           <FastForwardIcon size={IconSize.md} />
         </ActionIcon>

--- a/src/panels/TimePanel/TimeInput/TimeInput.tsx
+++ b/src/panels/TimePanel/TimeInput/TimeInput.tsx
@@ -1,5 +1,14 @@
 import { useRef, useState } from 'react';
-import { ActionIcon, Alert, Button, Group, Paper, Stack, Text } from '@mantine/core';
+import {
+  ActionIcon,
+  Alert,
+  Button,
+  Group,
+  Paper,
+  Stack,
+  Text,
+  Tooltip
+} from '@mantine/core';
 import { useWindowEvent } from '@mantine/hooks';
 
 import { useOpenSpaceApi } from '@/api/hooks';
@@ -261,9 +270,20 @@ export function TimeInput() {
     <Paper bg={'dark.9'} withBorder={isLocked} m={0} p={'xs'}>
       <Stack gap={'xs'}>
         <Group gap={'xs'} justify={'center'}>
-          <ActionIcon onClick={toggleLock} variant={isLocked ? 'filled' : 'default'}>
-            {isLocked ? <LockIcon /> : <LockOpenIcon />}
-          </ActionIcon>
+          <Tooltip
+            label={
+              'Lock time updates to prevent automatic changes. Use "Interpolate" or "Set"' +
+              ' to manually apply the selected date and time.'
+            }
+          >
+            <ActionIcon
+              onClick={toggleLock}
+              variant={isLocked ? 'filled' : 'default'}
+              aria-label={`${isLocked ? 'Disable' : 'Enable'} manual date and time updates`}
+            >
+              {isLocked ? <LockIcon /> : <LockOpenIcon />}
+            </ActionIcon>
+          </Tooltip>
           <Group gap={5} wrap={'nowrap'}>
             <TimeIncrementInput
               value={time.getUTCFullYear()}

--- a/src/panels/UserPanelsPanel/UserPanelsPanel.tsx
+++ b/src/panels/UserPanelsPanel/UserPanelsPanel.tsx
@@ -114,7 +114,12 @@ export function UserPanelsPanel() {
           flex={1}
           onKeyDown={(e) => e.key === 'Enter' && addLocalPanel()}
         />
-        <ActionIcon onClick={addLocalPanel} disabled={!selectedPanel} size={'lg'}>
+        <ActionIcon
+          onClick={addLocalPanel}
+          disabled={!selectedPanel}
+          size={'lg'}
+          aria-label={'Open local panel'}
+        >
           <OpenWindowIcon />
         </ActionIcon>
       </Group>
@@ -137,7 +142,12 @@ export function UserPanelsPanel() {
           onKeyDown={(e) => e.key === 'Enter' && addWebPanel()}
           flex={1}
           rightSection={
-            <ActionIcon onClick={addWebPanel} disabled={!panelURL} size={'lg'}>
+            <ActionIcon
+              onClick={addWebPanel}
+              disabled={!panelURL}
+              size={'lg'}
+              aria-label={'Open web panel'}
+            >
               <OpenWindowIcon />
             </ActionIcon>
           }


### PR DESCRIPTION
Added aria labels to all action icons. I wasn't sure about `ColorPicker` where and how it is used, so this one still needs a label. In some lists where we have many add or remove buttons, I've added the identifier to at least get some info on which node it is about. Do we want to pass the name of the node to these components as well to get a nicer readout? 

