### PR TITLE
Fix broken exoplanet settings

### DIFF
--- a/src/panels/ExoplanetsPanel/ExoplanetsPanel.tsx
+++ b/src/panels/ExoplanetsPanel/ExoplanetsPanel.tsx
@@ -2,39 +2,29 @@ import { useEffect } from 'react';
 import { Divider, Text, Title } from '@mantine/core';
 
 import { useOpenSpaceApi } from '@/api/hooks';
-import { Collapsable } from '@/components/Collapsable/Collapsable';
 import { FilterList } from '@/components/FilterList/FilterList';
 import { wordBeginningSubString } from '@/components/FilterList/util';
-import { Property } from '@/components/Property/Property';
 import { ResizeableContent } from '@/components/ResizeableContent/ResizeableContent';
 import { useStringProperty } from '@/hooks/properties';
 import { initializeExoplanets } from '@/redux/exoplanets/exoplanetsSlice';
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
 import { Identifier } from '@/types/types';
-import {
-  HabitableZonePropertyKey,
-  NavigationAimKey,
-  NavigationAnchorKey,
-  Size1AuRingPropertyKey,
-  UncertaintyDiscPropertyKey
-} from '@/util/keys';
+import { NavigationAimKey, NavigationAnchorKey } from '@/util/keys';
 import { sgnUri } from '@/util/propertyTreeHelpers';
 
 import { SceneGraphNodeHeader } from '../Scene/SceneGraphNode/SceneGraphNodeHeader';
 
 import { ExoplanetEntry } from './ExoplanetEntry';
+import { ExoplanetsSettings } from './ExoplanetsSettings';
 
 export function ExoplanetsPanel() {
-  const luaApi = useOpenSpaceApi();
-
-  const propertyOwners = useAppSelector((state) => {
-    return state.propertyOwners.propertyOwners;
-  });
-
+  const propertyOwners = useAppSelector((state) => state.propertyOwners.propertyOwners);
   const isDataInitialized = useAppSelector((state) => state.exoplanets.isInitialized);
   const allSystemNames = useAppSelector((state) => state.exoplanets.data);
+
   const [aim, setAim] = useStringProperty(NavigationAimKey);
   const [anchor, setAnchor] = useStringProperty(NavigationAnchorKey);
+  const luaApi = useOpenSpaceApi();
 
   const dispatch = useAppDispatch();
 
@@ -109,11 +99,7 @@ export function ExoplanetsPanel() {
           </FilterList.SearchResults>
         </FilterList>
       </ResizeableContent>
-      <Collapsable title={'Settings'}>
-        <Property uri={HabitableZonePropertyKey} />
-        <Property uri={UncertaintyDiscPropertyKey} />
-        <Property uri={Size1AuRingPropertyKey} />
-      </Collapsable>
+      <ExoplanetsSettings hasAddedExoplanets={addedSystems.length > 0} />
       <Divider my={'xs'}></Divider>
       <Title order={3}>Added Systems</Title>
       {addedSystems.length === 0 ? (

--- a/src/panels/ExoplanetsPanel/ExoplanetsSettings.tsx
+++ b/src/panels/ExoplanetsPanel/ExoplanetsSettings.tsx
@@ -12,12 +12,6 @@ interface Props {
 export function ExoplanetsSettings({ hasAddedExoplanets }: Props) {
   const luaApi = useOpenSpaceApi();
 
-  const Tags = {
-    UncertaintyDisc: 'exoplanet_uncertainty_disc',
-    HabitableZone: 'exoplanet_habitable_zone',
-    Size1AuRing: 'exoplanet_1au_ring'
-  };
-
   const [showHabitableZone, setShowHabitableZone] = useBoolProperty(
     'Modules.Exoplanets.ShowHabitableZone'
   );
@@ -27,6 +21,12 @@ export function ExoplanetsSettings({ hasAddedExoplanets }: Props) {
   const [show1AuRing, setShow1AuRing] = useBoolProperty(
     'Modules.Exoplanets.ShowComparisonCircle'
   );
+
+  const Tags = {
+    UncertaintyDisc: 'exoplanet_uncertainty_disc',
+    HabitableZone: 'exoplanet_habitable_zone',
+    Size1AuRing: 'exoplanet_1au_ring'
+  };
 
   function toggleShowHabitableZone() {
     const shouldShow = !showHabitableZone;

--- a/src/panels/ExoplanetsPanel/ExoplanetsSettings.tsx
+++ b/src/panels/ExoplanetsPanel/ExoplanetsSettings.tsx
@@ -1,0 +1,108 @@
+import { Checkbox, Group, Stack } from '@mantine/core';
+
+import { useOpenSpaceApi } from '@/api/hooks';
+import { Collapsable } from '@/components/Collapsable/Collapsable';
+import { InfoBox } from '@/components/InfoBox/InfoBox';
+import { useBoolProperty } from '@/hooks/properties';
+
+interface Props {
+  hasAddedExoplanets: boolean;
+}
+
+export function ExoplanetsSettings({ hasAddedExoplanets }: Props) {
+  const luaApi = useOpenSpaceApi();
+
+  const Tags = {
+    UncertaintyDisc: 'exoplanet_uncertainty_disc',
+    HabitableZone: 'exoplanet_habitable_zone',
+    Size1AuRing: 'exoplanet_1au_ring'
+  };
+
+  const [showHabitableZone, setShowHabitableZone] = useBoolProperty(
+    'Modules.Exoplanets.ShowHabitableZone'
+  );
+  const [showOrbitUncertainty, setShowOrbitUncertainty] = useBoolProperty(
+    'Modules.Exoplanets.ShowOrbitUncertainty'
+  );
+  const [show1AuRing, setShow1AuRing] = useBoolProperty(
+    'Modules.Exoplanets.ShowComparisonCircle'
+  );
+
+  function toggleShowHabitableZone() {
+    const shouldShow = !showHabitableZone;
+    setShowHabitableZone(shouldShow);
+    // Also disable all previously enabled exoplanet habitable zones
+    if (hasAddedExoplanets) {
+      luaApi?.setPropertyValue(`{${Tags.HabitableZone}}.Renderable.Enabled`, shouldShow);
+    }
+  }
+
+  function toggleShowOrbitUncertainty() {
+    const shouldShow = !showOrbitUncertainty;
+    setShowOrbitUncertainty(shouldShow);
+    // Also disable all previously enabled exoplanet orbit uncertainty discs
+    if (hasAddedExoplanets) {
+      luaApi?.setPropertyValue(
+        `{${Tags.UncertaintyDisc}}.Renderable.Enabled`,
+        shouldShow
+      );
+    }
+  }
+
+  function toggleShow1AuRing() {
+    const shouldShow = !show1AuRing;
+    setShow1AuRing(shouldShow);
+    // Also disable all previously enabled exoplanet orbit uncertainty discs
+    if (hasAddedExoplanets) {
+      luaApi?.setPropertyValue(`{${Tags.Size1AuRing}}.Renderable.Enabled`, shouldShow);
+    }
+  }
+
+  return (
+    <Collapsable title={'Settings'}>
+      <Stack gap={'xs'}>
+        <Group>
+          <Checkbox
+            checked={showHabitableZone}
+            onChange={toggleShowHabitableZone}
+            onKeyDown={(event) => event.key === 'Enter' && toggleShowHabitableZone()}
+            aria-label={`Toggle Show Habitable Zone`}
+            label={'Show Habitable Zone'}
+          />
+          <InfoBox>
+            Show/Hide the habitable zone visualizations. Setting the value automatically
+            updates the visibility for all added exoplanet systems
+          </InfoBox>
+        </Group>
+        <Group>
+          <Checkbox
+            checked={showOrbitUncertainty}
+            onChange={toggleShowOrbitUncertainty}
+            onKeyDown={(event) => event.key === 'Enter' && toggleShowOrbitUncertainty()}
+            aria-label={`Toggle Show Orbit Uncertainty`}
+            label={'Show Orbit Uncertainty'}
+          />
+          <InfoBox>
+            Show/Hide disc visualization of the uncertainty of the planetary orbits.
+            Setting the value automatically updates the visibility for all added exoplanet
+            systems
+          </InfoBox>
+        </Group>
+        <Group>
+          <Checkbox
+            checked={show1AuRing}
+            onChange={toggleShow1AuRing}
+            onKeyDown={(event) => event.key === 'Enter' && toggleShow1AuRing()}
+            aria-label={`Toggle Show 1 AU Size Ring`}
+            label={'Show 1 AU Size Ring'}
+          />
+          <InfoBox>
+            If true, show a ring with the radius 1 AU around the host star of each system,
+            to use for size comparison. Setting the value automatically updates the
+            visibility for all added exoplanet systems
+          </InfoBox>
+        </Group>
+      </Stack>
+    </Collapsable>
+  );
+}

--- a/src/panels/ExoplanetsPanel/ExoplanetsSettings.tsx
+++ b/src/panels/ExoplanetsPanel/ExoplanetsSettings.tsx
@@ -71,7 +71,7 @@ export function ExoplanetsSettings({ hasAddedExoplanets }: Props) {
           />
           <InfoBox>
             Show/Hide the habitable zone visualizations. Setting the value automatically
-            updates the visibility for all added exoplanet systems
+            updates the visibility for all added exoplanet systems.
           </InfoBox>
         </Group>
         <Group>
@@ -85,7 +85,7 @@ export function ExoplanetsSettings({ hasAddedExoplanets }: Props) {
           <InfoBox>
             Show/Hide disc visualization of the uncertainty of the planetary orbits.
             Setting the value automatically updates the visibility for all added exoplanet
-            systems
+            systems.
           </InfoBox>
         </Group>
         <Group>
@@ -99,7 +99,7 @@ export function ExoplanetsSettings({ hasAddedExoplanets }: Props) {
           <InfoBox>
             If true, show a ring with the radius 1 AU around the host star of each system,
             to use for size comparison. Setting the value automatically updates the
-            visibility for all added exoplanet systems
+            visibility for all added exoplanet systems.
           </InfoBox>
         </Group>
       </Stack>

--- a/src/util/keys.ts
+++ b/src/util/keys.ts
@@ -26,13 +26,6 @@ export const GeoLocationGroupKey = '/GeoLocation';
 // OpenSpace engine
 export const EnginePropertyVisibilityKey = 'OpenSpaceEngine.PropertyVisibility';
 
-export const UncertaintyDiscTagKey = 'exoplanet_uncertainty_disc';
-export const UncertaintyDiscPropertyKey = 'Modules.Exoplanets.ShowOrbitUncertainty';
-export const HabitableZoneTagKey = 'exoplanet_habitable_zone';
-export const HabitableZonePropertyKey = 'Modules.Exoplanets.ShowHabitableZone';
-export const Size1AuRingTagKey = 'exoplanet_1au_ring';
-export const Size1AuRingPropertyKey = 'Modules.Exoplanets.ShowComparisonCircle';
-
 // OpenSpace folders
 // eslint-disable-next-line no-template-curly-in-string
 export const UserPanelsFolderKey = '${USER}/webpanels';


### PR DESCRIPTION
The functionality of applying the setting to the already existing exoplanet systems had been lost in the rewrite. 

**To discuss:** This PR could be closed if we instead handle the updating of the existing systems on the engine side, in the onchange of the module's properties. What's your preference?