### PR TITLE
Fix/broken properties

### DIFF
--- a/src/components/Property/Types/BoolProperty.tsx
+++ b/src/components/Property/Types/BoolProperty.tsx
@@ -13,7 +13,7 @@ export function BoolProperty({ uri, readOnly }: PropertyProps) {
     <BoolInput
       value={value}
       setValue={setValue}
-      name={meta.name}
+      name={meta.guiName}
       description={meta.description}
       readOnly={readOnly}
     />

--- a/src/components/Property/Types/TriggerProperty.tsx
+++ b/src/components/Property/Types/TriggerProperty.tsx
@@ -14,7 +14,7 @@ export function TriggerProperty({ uri, readOnly }: PropertyProps) {
 
   return (
     <Group>
-      <Button onClick={() => trigger()} disabled={readOnly}>
+      <Button onClick={() => trigger(null)} disabled={readOnly}>
         {meta.guiName}
       </Button>
       <InfoBox>

--- a/src/types/Property/property.ts
+++ b/src/types/Property/property.ts
@@ -15,26 +15,26 @@ type EmptyObject = Record<string, never>;
  * Extracts the `additionalData` property from a specific property type in `PropertyTypes`.
  *
  * This utility type checks if the specified property type in `PropertyTypes` contains
- * an `additionalData` field. If it does, it creates a new type with the `additionalData`
- * field. Otherwise, it defaults to an empty object type.
+ * an `additionalData` field. If it does, it uses the inferred type for the additional
+ * data. Otherwise, it defaults to an empty object type.
  */
 type AdditionalData<T extends keyof PropertyTypes> = PropertyTypes[T] extends {
   additionalData: infer A;
 }
-  ? { additionalData: A }
+  ? A
   : EmptyObject;
 
 /**
  * Extracts the `viewOptions` property from a specific property type in `PropertyTypes`.
  *
  * This utility type checks if the specified property type in `PropertyTypes` contains
- * an `viewOptions` field. If it does, it creates a new type with the `viewOptions`
- * field. Otherwise, it defaults to an empty object type.
+ * an `viewOptions` field. If it does, it uses the inferred type for the view options.
+ * Otherwise, it defaults to an empty object type.
  */
 type ViewOptions<T extends keyof PropertyTypes> = PropertyTypes[T] extends {
   viewOptions: infer A;
 }
-  ? { viewOptions: A }
+  ? A
   : EmptyObject;
 
 // Generic Property<T> type
@@ -47,8 +47,9 @@ type Property<T extends keyof PropertyTypes> = {
     group: string;
     needsConfirmation: boolean;
     visibility: PropertyVisibility;
-  } & AdditionalData<T> &
-    ViewOptions<T>;
+    additionalData: AdditionalData<T>;
+    viewOptions: ViewOptions<T>;
+  };
   value: PropertyTypes[T]['value'];
   uri: string;
 };

--- a/src/types/Property/propertyTypes.ts
+++ b/src/types/Property/propertyTypes.ts
@@ -85,7 +85,7 @@ interface MatrixProperty {
 
 export type PropertyTypes = {
   TriggerProperty: {
-    value: void;
+    value: null;
   };
   BoolProperty: {
     value: boolean;


### PR DESCRIPTION
Brings back the label for `BoolProperty` and fixes `TriggerProperty`, which led to an OpenSpace error on trigger due to the wrong type being used in the setValue function. 

Would have merged this to `master` directly, but would like a thumbs up from @ylvaselling just to see that the changes I made in `property.ts` makes sense.  

If I understand the problem correctly, using the `& AdditionalData<T> &
    ViewOptions<T>` for MetaData made the meta data object to somehow get the properties from the `EmptyObject` type, and somehow this made it so that we wouldn't get a type error when we wrote `meta.name` instead of `meta.guiName`. Not quite sure why the issue occurred, but this rewrite fixes it and still infers the correct type for the additional data and viewoptions
