### PR TITLE
Fix missing copy URI in property labels and split label component up into one specific for properties

### DIFF
--- a/src/components/Input/BoolInput.tsx
+++ b/src/components/Input/BoolInput.tsx
@@ -17,7 +17,7 @@ export function BoolInput({
   setValue,
   name,
   description,
-  label = undefined,
+  label,
   disabled = false
 }: Props) {
   return (

--- a/src/components/Input/BoolInput.tsx
+++ b/src/components/Input/BoolInput.tsx
@@ -8,7 +8,8 @@ interface Props {
   description: string | JSX.Element;
   value: boolean;
   setValue: (value: boolean) => void;
-  readOnly?: boolean;
+  label?: JSX.Element;
+  disabled?: boolean;
 }
 
 export function BoolInput({
@@ -16,7 +17,8 @@ export function BoolInput({
   setValue,
   name,
   description,
-  readOnly = false
+  label = undefined,
+  disabled = false
 }: Props) {
   return (
     <Group gap={'xs'} wrap={'nowrap'}>
@@ -24,10 +26,10 @@ export function BoolInput({
         checked={value}
         onChange={(event) => setValue(event.currentTarget.checked)}
         onKeyDown={(event) => event.key === 'Enter' && setValue(!value)}
-        disabled={readOnly}
+        disabled={disabled}
         aria-label={name}
       />
-      <Label name={name} description={description} readOnly={readOnly} />
+      {label || <Label name={name} description={description} />}
     </Group>
   );
 }

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,42 +1,22 @@
 import { JSX } from 'react';
-import { Group, InputLabel, Text, Tooltip } from '@mantine/core';
+import { Group, InputLabel, Text } from '@mantine/core';
 
-import CopyUriButton from '@/components/CopyUriButton/CopyUriButton';
 import { InfoBox } from '@/components/InfoBox/InfoBox';
-import { Uri } from '@/types/types';
 
 interface Props {
-  name: string;
+  name: string | JSX.Element;
   description: string | JSX.Element;
-  uri?: Uri;
-  readOnly?: boolean;
 }
 
-export function Label({ name, description, uri, readOnly = false }: Props) {
+export function Label({ name, description }: Props) {
   return (
     <Group wrap={'nowrap'}>
       <InputLabel fw={'normal'}>
         <Text span size={'sm'}>
           {name}
         </Text>
-        {readOnly && (
-          <Tooltip
-            maw={200}
-            multiline
-            label={`This property is read-only, meaning that it's not intended to be changed.`}
-          >
-            <Text span ml={'xs'} size={'xs'} c={'dimmed'}>
-              (Read-only)
-            </Text>
-          </Tooltip>
-        )}
       </InputLabel>
-      {description && (
-        <InfoBox>
-          {description}
-          {uri && <CopyUriButton uri={uri} />}
-        </InfoBox>
-      )}
+      {description && <InfoBox>{description}</InfoBox>}
     </Group>
   );
 }

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -4,7 +4,7 @@ import { Group, InputLabel, Text } from '@mantine/core';
 import { InfoBox } from '@/components/InfoBox/InfoBox';
 
 interface Props {
-  name: JSX.Element;
+  name: string | JSX.Element;
   description: string | JSX.Element;
 }
 

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -4,7 +4,7 @@ import { Group, InputLabel, Text } from '@mantine/core';
 import { InfoBox } from '@/components/InfoBox/InfoBox';
 
 interface Props {
-  name: string | JSX.Element;
+  name: JSX.Element;
   description: string | JSX.Element;
 }
 

--- a/src/components/Property/Property.tsx
+++ b/src/components/Property/Property.tsx
@@ -4,8 +4,6 @@ import { Stack } from '@mantine/core';
 import { useAppSelector } from '@/redux/hooks';
 import { Uri } from '@/types/types';
 
-import { Label } from '../Label/Label';
-
 import { BoolProperty } from './Types/BoolProperty';
 import { DoubleListProperty } from './Types/ListProperty/DoubleListProperty';
 import { IntListProperty } from './Types/ListProperty/IntListProperty';
@@ -17,6 +15,7 @@ import { SelectionProperty } from './Types/SelectionProperty';
 import { StringProperty } from './Types/StringProperty';
 import { TriggerProperty } from './Types/TriggerProperty';
 import { VectorProperty } from './Types/VectorProperty/VectorProperty';
+import { PropertyLabel } from './PropertyLabel';
 
 // The readOnly prop sent to each component are meant to enforce each
 // Property component to have to handle the readOnly state. This can
@@ -91,10 +90,11 @@ export const Property = memo(({ uri }: Props) => {
   return (
     <Stack mb={'md'} gap={5}>
       {showLabel && (
-        <Label
+        <PropertyLabel
           name={meta.guiName}
           description={meta.description}
           readOnly={meta.isReadOnly}
+          uri={uri}
         />
       )}
       {renderProperty(meta.type, uri, meta.isReadOnly)}

--- a/src/components/Property/PropertyLabel.tsx
+++ b/src/components/Property/PropertyLabel.tsx
@@ -1,0 +1,43 @@
+import { JSX } from 'react';
+import { Text, Tooltip } from '@mantine/core';
+
+import CopyUriButton from '@/components/CopyUriButton/CopyUriButton';
+import { Uri } from '@/types/types';
+
+import { Label } from '../Label/Label';
+
+interface Props {
+  name: string;
+  description: string | JSX.Element;
+  uri: Uri;
+  readOnly?: boolean;
+}
+
+export function PropertyLabel({ name, description, uri, readOnly = false }: Props) {
+  return (
+    <Label
+      name={
+        <>
+          {name}
+          {readOnly && (
+            <Tooltip
+              maw={200}
+              multiline
+              label={`This property is read-only, meaning that it's not intended to be changed.`}
+            >
+              <Text span ml={'xs'} size={'xs'} c={'dimmed'}>
+                (Read-only)
+              </Text>
+            </Tooltip>
+          )}
+        </>
+      }
+      description={
+        <>
+          {description}
+          {uri && <CopyUriButton uri={uri} />}
+        </>
+      }
+    />
+  );
+}

--- a/src/components/Property/PropertyLabel.tsx
+++ b/src/components/Property/PropertyLabel.tsx
@@ -2,13 +2,12 @@ import { JSX } from 'react';
 import { Text, Tooltip } from '@mantine/core';
 
 import CopyUriButton from '@/components/CopyUriButton/CopyUriButton';
+import { Label } from '@/components/Label/Label';
 import { Uri } from '@/types/types';
-
-import { Label } from '../Label/Label';
 
 interface Props {
   name: string;
-  description: JSX.Element;
+  description: string | JSX.Element;
   uri: Uri;
   readOnly?: boolean;
 }

--- a/src/components/Property/PropertyLabel.tsx
+++ b/src/components/Property/PropertyLabel.tsx
@@ -8,7 +8,7 @@ import { Label } from '../Label/Label';
 
 interface Props {
   name: string;
-  description: string | JSX.Element;
+  description: JSX.Element;
   uri: Uri;
   readOnly?: boolean;
 }

--- a/src/components/Property/Types/BoolProperty.tsx
+++ b/src/components/Property/Types/BoolProperty.tsx
@@ -2,6 +2,8 @@ import { BoolInput } from '@/components/Input/BoolInput';
 import { PropertyProps } from '@/components/Property/types';
 import { useProperty } from '@/hooks/properties';
 
+import { PropertyLabel } from '../PropertyLabel';
+
 export function BoolProperty({ uri, readOnly }: PropertyProps) {
   const [value, setValue, meta] = useProperty('BoolProperty', uri);
 
@@ -13,9 +15,17 @@ export function BoolProperty({ uri, readOnly }: PropertyProps) {
     <BoolInput
       value={value}
       setValue={setValue}
-      name={meta.name}
+      name={meta.guiName}
       description={meta.description}
-      readOnly={readOnly}
+      disabled={readOnly}
+      label={
+        <PropertyLabel
+          name={meta.guiName}
+          description={meta.description}
+          uri={uri}
+          readOnly={readOnly}
+        />
+      }
     />
   );
 }


### PR DESCRIPTION
As part of a recent PR, the code for property labels had been rewritten to use a common Label component that can be used for inputs that are not properties. 

This PR fixes some issues with that rewrite: 

1. The copy URI button had disappeared for all property types, and it would not have been possible to add it to a `BoolProperty`. Now, the `BoolInput` component can take a custom label component, so that we can use the `PropertyLabel` for it for bool properties. 
2.  The generic `Label` component now knows nothing about properties. It was confusing to me that it had a bunch of property-specific text when it was seemingly intended to be a generic label that can be used for anything for which we want an infobox description. Instead, there is a specific `PropertyLabel` component, that uses the `Label` component so that the visual style is the same

Some questions/TODOs:
- We should use the `BoolInput` component everywhere we are currently using a `Checkbox` component. Do you think I should do this as part of this PR @ylvaselling @engbergandreas ?
- What's the intended use of the `Label` component @ylvaselling?  Is it only for inputs, or for anything?  If it's only for inputs, maybe we should rename it to `InputLabel`