### PR TITLE
Language/components

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,0 +1,3 @@
+{
+    "cancel": "Cancel"
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,3 +1,3 @@
 {
-    "cancel": "Cancel"
+  "cancel": "Cancel"
 }

--- a/public/locales/en/components.json
+++ b/public/locales/en/components.json
@@ -2,11 +2,134 @@
   "about": {
     "modal-title": "About OpenSpace",
     "img-alt-text": "OpenSpace logo",
-    "about-openspace": "OpenSpace is open-source interactive data visualization software designed to visualize the entire known universe and portray our ongoing efforts to investigate the cosmos.",
+    "about-openspace-description": "OpenSpace is open-source interactive data visualization software designed to visualize the entire known universe and portray our ongoing efforts to investigate the cosmos.",
     "fetching-version-number": "Fetching OpenSpace version...",
     "custom-version-number": "Custom"
   },
   "collapsable-header": {
-    "chevron-aria-label": "{{variable}} ? open : close "
+    "chevron-aria-label": {
+      "open": "Open",
+      "close": "Close"
+    }
+  },
+  "color-edit": {
+    "error-invalid-color": "Invalid color"
+  },
+  "color-picker": {
+    "color-swatch-aria-label": "Open color edit"
+  },
+  "copy-to-clipboard-button": {
+    "tooltip": {
+      "copy": "Copy",
+      "copied": "Copied"
+    },
+    "label": "Copy"
+  },
+  "copy-uri-button": {
+    "label": "Copy URI:"
+  },
+  "drag-reorder-list": {
+    "drag-handle-aria-label": "Move item up or down (keyboard control not supported)"
+  },
+  "error-fallback": {
+    "alert-title": "🚨 Houston, we have a problem...🚨",
+    "alert-text": "An error with the following message was thrown:",
+    "reload-button-label": "Reload page"
+  },
+  "filter-list": {
+    "search-results": {
+      "empty-results": "No results found. Try another search!"
+    },
+    "search-settings-menu": {
+      "no-selection-tooltip": "Nothing is selected. Search will be empty.",
+      "dropdown-menu-label": "Search in"
+    },
+    "filter-list-input-field": {
+      "cancel-button-aria-label": "Clear search input",
+      "show-more-button": {
+        "less": "Less",
+        "more": "More"
+      }
+    }
+  },
+  "friction-controls": {
+    "rotation-label": "Rotation",
+    "zoom-label": "Zoom",
+    "roll-label": "Roll"
+  },
+  "friction-controls-info": {
+    "heading": "Friction controls",
+    "description": "Enable or disable rotation, zoom, and roll friction. If checked, applies friction to camera movement."
+  },
+  "info-box": {
+    "aria-label": "More information"
+  },
+  "input": {
+    "numeric-input": {
+      "error-label": "Value outside range [{{min}}, {{max}}]"
+    },
+    "step-control-button": {
+      "aria-label": {
+        "increment": "Increment value",
+        "decrement": "Decrement value"
+      }
+    }
+  },
+  "node-navigation-button": {
+    "jump": {
+      "title": "Jump to",
+      "tooltip": "Teleport to object using a fade transition"
+    },
+    "jump-geo": {
+      "title": "Jump to Geo",
+      "tooltip": "Teleport to position using a fade transition"
+    },
+    "focus": {
+      "title": "Focus",
+      "tooltip": "Focus the object (set as anchor). Hold <0>Shift</0> when clicking to focus without retargeting"
+    },
+    "fly": {
+      "title": "Fly to",
+      "tooltip": "Trigger a flight to the object. Hold <0>Shift</0> when clicking to instantly teleport/jump"
+    },
+    "fly-geo": {
+      "title": "Fly to Geo",
+      "tooltip": "Trigger a flight to the position. Hold <0>Shift</0> when clicking to instantly teleport/jump"
+    },
+    "frame": {
+      "title": "Zoom to / Frame",
+      "tooltip": "Frame the object by moving the camera in a straigt line and rotate towards it. Hold <0>Shift</0> when clicking to do it instantaneously"
+    }
+  },
+  "property": {
+    "list-property": {
+      "double-list-placeholder-text": "number1, number2, ...",
+      "int-list-placeholder-text": "integer1, integer2, ...",
+      "string-list-placeholder-text": "item1, item2, ..."
+    },
+    "option-property": {
+      "aria-label": "{{guiName}} option input",
+      "placeholder": {
+        "options": "Choose an option",
+        "no-options": "No options were loaded"
+      }
+    },
+    "selection-property": {
+      "aria-label": "{{guiName}} multi-select",
+      "placeholder-empty-field": "No selection"
+    },
+    "string-property": {
+      "aria-label": "{{guiName}} input"
+    },
+    "property-label": {
+      "tooltip-label": "This property is read-only, meaning that it's not intended to be changed.",
+      "label": "(Read-only)"
+    }
+  },
+  "resizeable-content": {
+    "aria-label": "Resize window (keyboard control not suppored)"
+  },
+  "settings-popout": {
+    "aria-label": "Open settings"
   }
 }

--- a/public/locales/en/components.json
+++ b/public/locales/en/components.json
@@ -1,7 +1,7 @@
 {
   "about": {
     "modal-title": "About OpenSpace",
-    "img-alt-text": "OpenSpace logo",
+    "logo-alt-text": "OpenSpace logo",
     "about-openspace-description": "OpenSpace is open-source interactive data visualization software designed to visualize the entire known universe and portray our ongoing efforts to investigate the cosmos.",
     "fetching-version-number": "Fetching OpenSpace version...",
     "custom-version-number": "Custom"
@@ -26,7 +26,7 @@
     "label": "Copy"
   },
   "copy-uri-button": {
-    "label": "Copy URI:"
+    "label": "Copy URI"
   },
   "drag-reorder-list": {
     "drag-handle-aria-label": "Move item up or down (keyboard control not supported)"
@@ -122,8 +122,8 @@
       "aria-label": "{{guiName}} input"
     },
     "property-label": {
-      "tooltip-label": "This property is read-only, meaning that it's not intended to be changed.",
-      "label": "(Read-only)"
+      "read-only-tooltip": "This property is read-only, meaning that it's not intended to be changed.",
+      "read-only-label": "Read-only"
     }
   },
   "resizeable-content": {

--- a/public/locales/en/components.json
+++ b/public/locales/en/components.json
@@ -44,7 +44,7 @@
       "no-selection-tooltip": "Nothing is selected. Search will be empty.",
       "dropdown-menu-label": "Search in"
     },
-    "filter-list-input-field": {
+    "input-field": {
       "cancel-button-aria-label": "Clear search input",
       "show-more-button": {
         "less": "Less",
@@ -55,11 +55,11 @@
   "friction-controls": {
     "rotation-label": "Rotation",
     "zoom-label": "Zoom",
-    "roll-label": "Roll"
-  },
-  "friction-controls-info": {
-    "heading": "Friction controls",
-    "description": "Enable or disable rotation, zoom, and roll friction. If checked, applies friction to camera movement."
+    "roll-label": "Roll",
+    "info": {
+      "heading": "Friction controls",
+      "description": "Enable or disable rotation, zoom, and roll friction. If checked, applies friction to camera movement."
+    }
   },
   "info-box": {
     "aria-label": "More information"

--- a/public/locales/en/components.json
+++ b/public/locales/en/components.json
@@ -1,0 +1,12 @@
+{
+  "about": {
+    "modal-title": "About OpenSpace",
+    "img-alt-text": "OpenSpace logo",
+    "about-openspace": "OpenSpace is open-source interactive data visualization software designed to visualize the entire known universe and portray our ongoing efforts to investigate the cosmos.",
+    "fetching-version-number": "Fetching OpenSpace version...",
+    "custom-version-number": "Custom"
+  },
+  "collapsable-header": {
+    "chevron-aria-label": "{{variable}} ? open : close "
+  }
+}

--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Anchor, Grid, Image, Modal, Stack, Text, Title } from '@mantine/core';
 
 import { useAppSelector } from '@/redux/hooks';
@@ -10,35 +11,32 @@ interface Props {
 
 export function About({ opened, close }: Props) {
   const openSpaceVersion = useAppSelector((state) => state.version.openSpaceVersion);
+  const { t } = useTranslation('components');
 
   function osVersionNumber(): string {
     if (!openSpaceVersion) {
-      return 'Fetching OpenSpace version...';
+      return t('about.fetching-version-number');
     }
 
     function formatVersion(version: SemanticVersion): string {
       return version.major !== 255 && version.minor !== 255 && version.patch !== 255
         ? `${version.major}.${version.minor}.${version.patch}`
-        : 'Custom';
+        : t('about.custom-version-number');
     }
 
     return `OpenSpace version: ${formatVersion(openSpaceVersion)}`;
   }
 
   return (
-    <Modal opened={opened} onClose={close} title={'About OpenSpace'} size={'40%'}>
+    <Modal opened={opened} onClose={close} title={t('about.modal-title')} size={'40%'}>
       <Grid>
         <Grid.Col span={4}>
-          <Image src={'openspace-logo.png'} alt={'OpenSpace logo'} w={'100%'} />
+          <Image src={'openspace-logo.png'} alt={t('about.img-alt-text')} w={'100%'} />
         </Grid.Col>
         <Grid.Col span={8}>
           <Stack gap={'xs'}>
             <Title order={1}>OpenSpace</Title>
-            <Text>
-              OpenSpace is open-source interactive data visualization software designed to
-              visualize the entire known universe and portray our ongoing efforts to
-              investigate the cosmos.
-            </Text>
+            <Text>{t('about.about-openspace')}</Text>
             <Text>{osVersionNumber()}</Text>
             <Text>
               &copy; 2014 - {new Date().getFullYear()} OpenSpace Development Team

--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -36,7 +36,7 @@ export function About({ opened, close }: Props) {
         <Grid.Col span={8}>
           <Stack gap={'xs'}>
             <Title order={1}>OpenSpace</Title>
-            <Text>{t('about.about-openspace')}</Text>
+            <Text>{t('about.about-openspace-description')}</Text>
             <Text>{osVersionNumber()}</Text>
             <Text>
               &copy; 2014 - {new Date().getFullYear()} OpenSpace Development Team

--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -11,32 +11,32 @@ interface Props {
 
 export function About({ opened, close }: Props) {
   const openSpaceVersion = useAppSelector((state) => state.version.openSpaceVersion);
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'about' });
 
   function osVersionNumber(): string {
     if (!openSpaceVersion) {
-      return t('about.fetching-version-number');
+      return t('fetching-version-number');
     }
 
     function formatVersion(version: SemanticVersion): string {
       return version.major !== 255 && version.minor !== 255 && version.patch !== 255
         ? `${version.major}.${version.minor}.${version.patch}`
-        : t('about.custom-version-number');
+        : t('custom-version-number');
     }
 
     return `OpenSpace version: ${formatVersion(openSpaceVersion)}`;
   }
 
   return (
-    <Modal opened={opened} onClose={close} title={t('about.modal-title')} size={'40%'}>
+    <Modal opened={opened} onClose={close} title={t('modal-title')} size={'40%'}>
       <Grid>
         <Grid.Col span={4}>
-          <Image src={'openspace-logo.png'} alt={t('about.img-alt-text')} w={'100%'} />
+          <Image src={'openspace-logo.png'} alt={t('img-alt-text')} w={'100%'} />
         </Grid.Col>
         <Grid.Col span={8}>
           <Stack gap={'xs'}>
             <Title order={1}>OpenSpace</Title>
-            <Text>{t('about.about-openspace-description')}</Text>
+            <Text>{t('about-openspace-description')}</Text>
             <Text>{osVersionNumber()}</Text>
             <Text>
               &copy; 2014 - {new Date().getFullYear()} OpenSpace Development Team

--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -31,7 +31,7 @@ export function About({ opened, close }: Props) {
     <Modal opened={opened} onClose={close} title={t('modal-title')} size={'40%'}>
       <Grid>
         <Grid.Col span={4}>
-          <Image src={'openspace-logo.png'} alt={t('img-alt-text')} w={'100%'} />
+          <Image src={'openspace-logo.png'} alt={t('logo-alt-text')} w={'100%'} />
         </Grid.Col>
         <Grid.Col span={8}>
           <Stack gap={'xs'}>

--- a/src/components/Collapsable/CollapsableHeader/CollapsableHeader.tsx
+++ b/src/components/Collapsable/CollapsableHeader/CollapsableHeader.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { ActionIcon, Group, MantineStyleProps, UnstyledButton } from '@mantine/core';
 
 import { ThreePartHeader } from '@/components/ThreePartHeader/ThreePartHeader';
@@ -22,12 +23,16 @@ export function CollapsableHeader({
   rightSection,
   ...styleProps
 }: Props) {
+  const { t } = useTranslation('components', { keyPrefix: 'collapsable-header' });
+
   return (
     <Group wrap={'nowrap'} gap={0} className={classes.header} {...styleProps}>
       <ActionIcon
         variant={'transparent'}
         onClick={toggle}
-        aria-label={`${expanded ? 'Open' : 'Close'} ${title}`}
+        aria-label={`${
+          expanded ? t('chevron-aria-label.open') : t('chevron-aria-label.close')
+        } ${title}`}
       >
         {expanded ? (
           <ChevronDownIcon size={IconSize.xs} />

--- a/src/components/ColorPicker/ColorEdit.tsx
+++ b/src/components/ColorPicker/ColorEdit.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   ColorInput,
   ColorPicker as MantineColorPicker,
@@ -25,6 +26,7 @@ export function ColorEdit({ color, onChange, withAlpha }: Props) {
   const [format, setFormat] = useState<ColorFormat>(defaultFormat);
   const [value, setValue] = useState(rgbaToColor(color, withAlpha));
   const [textEditValue, setTextEditValue] = useState(rgbaToColor(color, withAlpha));
+  const { t } = useTranslation('components');
 
   useEffect(() => {
     const updatedColor = rgbaToFormat(color, format || defaultFormat);
@@ -74,7 +76,7 @@ export function ColorEdit({ color, onChange, withAlpha }: Props) {
         }}
         onChange={setTextEditValue}
         format={format}
-        error={warnAboutInvalidColor ? 'Invalid color' : null}
+        error={warnAboutInvalidColor ? t('color-edit.error-invalid-color') : null}
       />
       <Select
         data={formats.map((value) => ({ value, label: value.toUpperCase() }))}

--- a/src/components/ColorPicker/ColorEdit.tsx
+++ b/src/components/ColorPicker/ColorEdit.tsx
@@ -26,7 +26,7 @@ export function ColorEdit({ color, onChange, withAlpha }: Props) {
   const [format, setFormat] = useState<ColorFormat>(defaultFormat);
   const [value, setValue] = useState(rgbaToColor(color, withAlpha));
   const [textEditValue, setTextEditValue] = useState(rgbaToColor(color, withAlpha));
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'color-edit' });
 
   useEffect(() => {
     const updatedColor = rgbaToFormat(color, format || defaultFormat);
@@ -76,7 +76,7 @@ export function ColorEdit({ color, onChange, withAlpha }: Props) {
         }}
         onChange={setTextEditValue}
         format={format}
-        error={warnAboutInvalidColor ? t('color-edit.error-invalid-color') : null}
+        error={warnAboutInvalidColor ? t('error-invalid-color') : null}
       />
       <Select
         data={formats.map((value) => ({ value, label: value.toUpperCase() }))}

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 export function ColorPicker({ color, disabled, onChange, withAlpha }: Props) {
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'color-picker' });
 
   return (
     <Popover position={'right-end'} withArrow arrowPosition={'center'}>
@@ -22,7 +22,7 @@ export function ColorPicker({ color, disabled, onChange, withAlpha }: Props) {
           disabled={disabled}
           size={'lg'}
           variant={'subtle'}
-          aria-label={t('color-picker.color-swatch-aria-label')}
+          aria-label={t('color-swatch-aria-label')}
         >
           <ColorSwatch color={rgbaToColor(color, withAlpha)} />
         </ActionIcon>

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { ActionIcon, ColorSwatch, Popover, RGBA } from '@mantine/core';
 
 import { rgbaToColor } from '@/util/colorHelper';
@@ -12,6 +13,8 @@ interface Props {
 }
 
 export function ColorPicker({ color, disabled, onChange, withAlpha }: Props) {
+  const { t } = useTranslation('components');
+
   return (
     <Popover position={'right-end'} withArrow arrowPosition={'center'}>
       <Popover.Target>
@@ -19,7 +22,7 @@ export function ColorPicker({ color, disabled, onChange, withAlpha }: Props) {
           disabled={disabled}
           size={'lg'}
           variant={'subtle'}
-          aria-label={'Open color edit'}
+          aria-label={t('color-picker.color-swatch-aria-label')}
         >
           <ColorSwatch color={rgbaToColor(color, withAlpha)} />
         </ActionIcon>

--- a/src/components/CopyToClipboardButton/CopyToClipboardButton.tsx
+++ b/src/components/CopyToClipboardButton/CopyToClipboardButton.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { ActionIcon, Button, CopyButton, Tooltip } from '@mantine/core';
 
 import { CopyIcon } from '@/icons/icons';
@@ -9,10 +10,19 @@ interface Props {
 }
 
 export function CopyToClipboardButton({ value, showLabel, disabled }: Props) {
+  const { t } = useTranslation('components');
+
   return (
     <CopyButton value={value} timeout={2000}>
       {({ copied, copy }) => (
-        <Tooltip label={copied ? 'Copied' : 'Copy'} position={'right'}>
+        <Tooltip
+          label={
+            copied
+              ? t('copy-to-clipboard-button.tooltip.copied')
+              : t('copy-to-clipboard-button.tooltip.copy')
+          }
+          position={'right'}
+        >
           {showLabel ? (
             <Button
               color={copied ? 'teal' : 'gray'}
@@ -21,7 +31,7 @@ export function CopyToClipboardButton({ value, showLabel, disabled }: Props) {
               rightSection={<CopyIcon />}
               disabled={disabled}
             >
-              Copy
+              {t('copy-to-clipboard-button.label')}
             </Button>
           ) : (
             <ActionIcon

--- a/src/components/CopyToClipboardButton/CopyToClipboardButton.tsx
+++ b/src/components/CopyToClipboardButton/CopyToClipboardButton.tsx
@@ -10,17 +10,13 @@ interface Props {
 }
 
 export function CopyToClipboardButton({ value, showLabel, disabled }: Props) {
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'copy-to-clipboard-button' });
 
   return (
     <CopyButton value={value} timeout={2000}>
       {({ copied, copy }) => (
         <Tooltip
-          label={
-            copied
-              ? t('copy-to-clipboard-button.tooltip.copied')
-              : t('copy-to-clipboard-button.tooltip.copy')
-          }
+          label={copied ? t('tooltip.copied') : t('tooltip.copy')}
           position={'right'}
         >
           {showLabel ? (
@@ -31,7 +27,7 @@ export function CopyToClipboardButton({ value, showLabel, disabled }: Props) {
               rightSection={<CopyIcon />}
               disabled={disabled}
             >
-              {t('copy-to-clipboard-button.label')}
+              {t('label')}
             </Button>
           ) : (
             <ActionIcon

--- a/src/components/CopyUriButton/CopyUriButton.tsx
+++ b/src/components/CopyUriButton/CopyUriButton.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Code, Group } from '@mantine/core';
 
 import { CopyToClipboardButton } from '../CopyToClipboardButton/CopyToClipboardButton';
@@ -7,11 +8,13 @@ interface Props {
 }
 
 function CopyUriButton({ uri }: Props) {
+  const { t } = useTranslation('components');
+
   return (
     <>
       {uri && (
         <Group pt={'sm'}>
-          <Code>Copy URI:</Code>
+          <Code>{t('copy-uri-button.label')}</Code>
           <CopyToClipboardButton value={uri} />
         </Group>
       )}

--- a/src/components/CopyUriButton/CopyUriButton.tsx
+++ b/src/components/CopyUriButton/CopyUriButton.tsx
@@ -14,7 +14,7 @@ function CopyUriButton({ uri }: Props) {
     <>
       {uri && (
         <Group pt={'sm'}>
-          <Code>{t('label')}</Code>
+          <Code>{t('label')}:</Code>
           <CopyToClipboardButton value={uri} />
         </Group>
       )}

--- a/src/components/CopyUriButton/CopyUriButton.tsx
+++ b/src/components/CopyUriButton/CopyUriButton.tsx
@@ -8,13 +8,13 @@ interface Props {
 }
 
 function CopyUriButton({ uri }: Props) {
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'copy-uri-button' });
 
   return (
     <>
       {uri && (
         <Group pt={'sm'}>
-          <Code>{t('copy-uri-button.label')}</Code>
+          <Code>{t('label')}</Code>
           <CopyToClipboardButton value={uri} />
         </Group>
       )}

--- a/src/components/DragReorderList/DragReorderList.tsx
+++ b/src/components/DragReorderList/DragReorderList.tsx
@@ -32,7 +32,7 @@ export function DragReorderList<T>({
   gap = 'xs'
 }: Props<T>) {
   const { value: localCache, setValue: setLocalCache } = usePropListeningState(data);
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'drag-reorder-list' });
 
   async function handleDragEnd(result: DropResult<string>) {
     if (!result.destination || result.source.index === result.destination.index) {
@@ -73,7 +73,7 @@ export function DragReorderList<T>({
                     <ActionIcon
                       style={{ cursor: 'grab' }}
                       {...item.dragHandleProps}
-                      aria-label={t('drag-reorder-list.drag-handle-aria-label')}
+                      aria-label={t('drag-handle-aria-label')}
                     >
                       <DragHandleIcon />
                     </ActionIcon>

--- a/src/components/DragReorderList/DragReorderList.tsx
+++ b/src/components/DragReorderList/DragReorderList.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { DragDropContext, Draggable, Droppable, DropResult } from '@hello-pangea/dnd';
 import { ActionIcon, Box, Group, MantineSpacing } from '@mantine/core';
 
@@ -31,6 +32,7 @@ export function DragReorderList<T>({
   gap = 'xs'
 }: Props<T>) {
   const { value: localCache, setValue: setLocalCache } = usePropListeningState(data);
+  const { t } = useTranslation('components');
 
   async function handleDragEnd(result: DropResult<string>) {
     if (!result.destination || result.source.index === result.destination.index) {
@@ -71,7 +73,7 @@ export function DragReorderList<T>({
                     <ActionIcon
                       style={{ cursor: 'grab' }}
                       {...item.dragHandleProps}
-                      aria-label={'Move item up or down (keyboard control not supported)'}
+                      aria-label={t('drag-reorder-list.drag-handle-aria-label')}
                     >
                       <DragHandleIcon />
                     </ActionIcon>

--- a/src/components/ErrorFallback/fallbackRender.tsx
+++ b/src/components/ErrorFallback/fallbackRender.tsx
@@ -8,16 +8,16 @@ import { Alert, Button, Code, Text } from '@mantine/core';
 // prop allows us to pass in a function where we can "recover" from the thrown
 // error, reset the error, and retry rendering.
 export function fallbackRender({ error, resetErrorBoundary }: FallbackProps) {
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'error-fallback' });
 
   return (
-    <Alert variant={'light'} color={'red'} title={t('error-fallback.alert-title')}>
-      <Text>{t('error-fallback.alert-text')}</Text>
+    <Alert variant={'light'} color={'red'} title={t('alert-title')}>
+      <Text>{t('alert-text')}</Text>
       <Code block my={'md'}>
         {error.message}
       </Code>
       <Button onClick={resetErrorBoundary} mt={'md'}>
-        {t('error-fallback.reload-button-label')}
+        {t('reload-button-label')}
       </Button>
     </Alert>
   );

--- a/src/components/ErrorFallback/fallbackRender.tsx
+++ b/src/components/ErrorFallback/fallbackRender.tsx
@@ -1,4 +1,5 @@
 import { FallbackProps } from 'react-error-boundary';
+import { useTranslation } from 'react-i18next';
 import { Alert, Button, Code, Text } from '@mantine/core';
 
 // This function is called by the npm package react-error-boundary when an
@@ -7,14 +8,16 @@ import { Alert, Button, Code, Text } from '@mantine/core';
 // prop allows us to pass in a function where we can "recover" from the thrown
 // error, reset the error, and retry rendering.
 export function fallbackRender({ error, resetErrorBoundary }: FallbackProps) {
+  const { t } = useTranslation('components');
+
   return (
-    <Alert variant={'light'} color={'red'} title={'🚨 Houston, we have a problem...🚨'}>
-      <Text>An error with the following message was thrown:</Text>
+    <Alert variant={'light'} color={'red'} title={t('error-fallback.alert-title')}>
+      <Text>{t('error-fallback.alert-text')}</Text>
       <Code block my={'md'}>
         {error.message}
       </Code>
       <Button onClick={resetErrorBoundary} mt={'md'}>
-        Reload page
+        {t('error-fallback.reload-button-label')}
       </Button>
     </Alert>
   );

--- a/src/components/FilterList/FilterListInputField.tsx
+++ b/src/components/FilterList/FilterListInputField.tsx
@@ -12,7 +12,7 @@ interface InputButtonProps {
 function InputButton({ showMoreButton }: InputButtonProps) {
   const { searchString, setSearchString, showDataInstead, toggleShowDataInstead } =
     useFilterListProvider();
-  const { t } = useTranslation('components', { keyPrefix: 'filter-list' });
+  const { t } = useTranslation('components', { keyPrefix: 'filter-list.input-field' });
 
   const isSearching = searchString !== '';
 
@@ -23,7 +23,7 @@ function InputButton({ showMoreButton }: InputButtonProps) {
         variant={'subtle'}
         color={'gray'}
         onClick={() => setSearchString('')}
-        aria-label={t('filter-list-input-field.cancel-button-aria-label')}
+        aria-label={t('cancel-button-aria-label')}
       >
         <CancelIcon />
       </ActionIcon>
@@ -33,9 +33,7 @@ function InputButton({ showMoreButton }: InputButtonProps) {
   return (
     showMoreButton && (
       <Button w={80} variant={'subtle'} color={'gray'} onClick={toggleShowDataInstead}>
-        {showDataInstead
-          ? t('filter-list-input-field.show-more-button.more')
-          : t('filter-list-input-field.show-more-button.more')}
+        {showDataInstead ? t('show-more-button.less') : t('show-more-button.more')}
       </Button>
     )
   );

--- a/src/components/FilterList/FilterListInputField.tsx
+++ b/src/components/FilterList/FilterListInputField.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { ActionIcon, Button, MantineStyleProps, TextInput } from '@mantine/core';
 
 import { CancelIcon } from '@/icons/icons';
@@ -11,6 +12,7 @@ interface InputButtonProps {
 function InputButton({ showMoreButton }: InputButtonProps) {
   const { searchString, setSearchString, showDataInstead, toggleShowDataInstead } =
     useFilterListProvider();
+  const { t } = useTranslation('components', { keyPrefix: 'filter-list' });
 
   const isSearching = searchString !== '';
 
@@ -21,7 +23,7 @@ function InputButton({ showMoreButton }: InputButtonProps) {
         variant={'subtle'}
         color={'gray'}
         onClick={() => setSearchString('')}
-        aria-label={'Clear search input'}
+        aria-label={t('filter-list-input-field.cancel-button-aria-label')}
       >
         <CancelIcon />
       </ActionIcon>
@@ -31,7 +33,9 @@ function InputButton({ showMoreButton }: InputButtonProps) {
   return (
     showMoreButton && (
       <Button w={80} variant={'subtle'} color={'gray'} onClick={toggleShowDataInstead}>
-        {showDataInstead ? 'Less' : 'More'}
+        {showDataInstead
+          ? t('filter-list-input-field.show-more-button.more')
+          : t('filter-list-input-field.show-more-button.more')}
       </Button>
     )
   );

--- a/src/components/FilterList/SearchResults/SearchResults.tsx
+++ b/src/components/FilterList/SearchResults/SearchResults.tsx
@@ -1,4 +1,5 @@
 import { PropsWithChildren, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Text } from '@mantine/core';
 
 import { LoadingBlocks } from '@/components/LoadingBlocks/LoadingBlocks';
@@ -26,6 +27,7 @@ export function SearchResults<T>({
   children
 }: Props<T>) {
   const { showFavorites, isLoading, searchString } = useFilterListProvider();
+  const { t } = useTranslation('components');
 
   // Memoizing this function so we don't need to recreate it when
   // the renderElement function changes
@@ -49,7 +51,9 @@ export function SearchResults<T>({
   }
 
   if (filteredItems.length === 0) {
-    return noResultsDisplay ?? <Text>No results found. Try another search!</Text>;
+    return (
+      noResultsDisplay ?? <Text>{t('filter-list.search-results.empty-results')}</Text>
+    );
   }
 
   return (

--- a/src/components/FilterList/SearchResults/SearchResults.tsx
+++ b/src/components/FilterList/SearchResults/SearchResults.tsx
@@ -27,7 +27,7 @@ export function SearchResults<T>({
   children
 }: Props<T>) {
   const { showFavorites, isLoading, searchString } = useFilterListProvider();
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'filter-list.search-results' });
 
   // Memoizing this function so we don't need to recreate it when
   // the renderElement function changes
@@ -51,9 +51,7 @@ export function SearchResults<T>({
   }
 
   if (filteredItems.length === 0) {
-    return (
-      noResultsDisplay ?? <Text>{t('filter-list.search-results.empty-results')}</Text>
-    );
+    return noResultsDisplay ?? <Text>{t('empty-results')}</Text>;
   }
 
   return (

--- a/src/components/FilterList/SearchSettingsMenu/FilterListSearchSettingsMenu.tsx
+++ b/src/components/FilterList/SearchSettingsMenu/FilterListSearchSettingsMenu.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import {
   ActionIcon,
   Checkbox,
@@ -23,13 +24,15 @@ export function FilterListSearchSettingsMenu<T extends object>({
   setKey,
   labels
 }: Props<T>) {
+  const { t } = useTranslation('components', { keyPrefix: 'filter-list' });
   const noKeyIsSelected = Object.values(keys).every((value) => value === false);
+
   return (
     <Menu position={'right-start'} withArrow closeOnItemClick={false}>
       <Menu.Target>
         <ActionIcon flex={'none'}>
           {noKeyIsSelected && (
-            <Tooltip label={'Nothing is selected. Search will be empty.'}>
+            <Tooltip label={t('search-settings-menu.no-selection-tooltip')}>
               <ThemeIcon
                 color={'orange.4'}
                 variant={'transparent'}
@@ -44,7 +47,7 @@ export function FilterListSearchSettingsMenu<T extends object>({
         </ActionIcon>
       </Menu.Target>
       <Menu.Dropdown maw={'300px'}>
-        <Menu.Label>Search in</Menu.Label>
+        <Menu.Label>{t('search-settings-menu.dropdown-menu-label')}</Menu.Label>
         <Stack p={'xs'}>
           {/* When using Object.entries a new object is created, and we cant infer the type from that */}
           {Object.entries(keys).map(([key, enabled]) => (

--- a/src/components/FilterList/SearchSettingsMenu/FilterListSearchSettingsMenu.tsx
+++ b/src/components/FilterList/SearchSettingsMenu/FilterListSearchSettingsMenu.tsx
@@ -24,7 +24,9 @@ export function FilterListSearchSettingsMenu<T extends object>({
   setKey,
   labels
 }: Props<T>) {
-  const { t } = useTranslation('components', { keyPrefix: 'filter-list' });
+  const { t } = useTranslation('components', {
+    keyPrefix: 'filter-list.search-settings-menu'
+  });
   const noKeyIsSelected = Object.values(keys).every((value) => value === false);
 
   return (
@@ -32,7 +34,7 @@ export function FilterListSearchSettingsMenu<T extends object>({
       <Menu.Target>
         <ActionIcon flex={'none'}>
           {noKeyIsSelected && (
-            <Tooltip label={t('search-settings-menu.no-selection-tooltip')}>
+            <Tooltip label={t('no-selection-tooltip')}>
               <ThemeIcon
                 color={'orange.4'}
                 variant={'transparent'}
@@ -47,7 +49,7 @@ export function FilterListSearchSettingsMenu<T extends object>({
         </ActionIcon>
       </Menu.Target>
       <Menu.Dropdown maw={'300px'}>
-        <Menu.Label>{t('search-settings-menu.dropdown-menu-label')}</Menu.Label>
+        <Menu.Label>{t('dropdown-menu-label')}</Menu.Label>
         <Stack p={'xs'}>
           {/* When using Object.entries a new object is created, and we cant infer the type from that */}
           {Object.entries(keys).map(([key, enabled]) => (

--- a/src/components/FrictionControls/FrictionControls.tsx
+++ b/src/components/FrictionControls/FrictionControls.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Chip, MantineSize } from '@mantine/core';
 
 import { useProperty } from '@/hooks/properties';
@@ -11,6 +12,7 @@ export function FrictionControls({ size }: Props) {
   const [rotation, setRotation] = useProperty('BoolProperty', RotationalFrictionKey);
   const [zoom, setZoom] = useProperty('BoolProperty', ZoomFrictionKey);
   const [roll, setRoll] = useProperty('BoolProperty', RollFrictionKey);
+  const { t } = useTranslation('components');
 
   return (
     <>
@@ -21,7 +23,7 @@ export function FrictionControls({ size }: Props) {
         size={size}
         color={'white'}
       >
-        Rotation
+        {t('friction-controls.rotation-label')}
       </Chip>
       <Chip
         checked={zoom}
@@ -30,7 +32,7 @@ export function FrictionControls({ size }: Props) {
         size={size}
         color={'white'}
       >
-        Zoom
+        {t('friction-controls.zoom-label')}
       </Chip>
       <Chip
         checked={roll}
@@ -39,7 +41,7 @@ export function FrictionControls({ size }: Props) {
         size={size}
         color={'white'}
       >
-        Roll
+        {t('friction-controls.roll-label')}
       </Chip>
     </>
   );

--- a/src/components/FrictionControls/FrictionControls.tsx
+++ b/src/components/FrictionControls/FrictionControls.tsx
@@ -12,7 +12,7 @@ export function FrictionControls({ size }: Props) {
   const [rotation, setRotation] = useProperty('BoolProperty', RotationalFrictionKey);
   const [zoom, setZoom] = useProperty('BoolProperty', ZoomFrictionKey);
   const [roll, setRoll] = useProperty('BoolProperty', RollFrictionKey);
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'friction-controls' });
 
   return (
     <>
@@ -23,7 +23,7 @@ export function FrictionControls({ size }: Props) {
         size={size}
         color={'white'}
       >
-        {t('friction-controls.rotation-label')}
+        {t('rotation-label')}
       </Chip>
       <Chip
         checked={zoom}
@@ -32,7 +32,7 @@ export function FrictionControls({ size }: Props) {
         size={size}
         color={'white'}
       >
-        {t('friction-controls.zoom-label')}
+        {t('zoom-label')}
       </Chip>
       <Chip
         checked={roll}
@@ -41,7 +41,7 @@ export function FrictionControls({ size }: Props) {
         size={size}
         color={'white'}
       >
-        {t('friction-controls.roll-label')}
+        {t('roll-label')}
       </Chip>
     </>
   );

--- a/src/components/FrictionControls/FrictionControlsInfo.tsx
+++ b/src/components/FrictionControls/FrictionControlsInfo.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Group, Stack, Text } from '@mantine/core';
 
 import { KeybindButtons } from '@/panels/KeybindsPanel/KeybindButtons';
@@ -5,6 +6,7 @@ import { useAppSelector } from '@/redux/hooks';
 
 export function FrictionControlsInfo() {
   const keybinds = useAppSelector((state) => state.actions.keybinds);
+  const { t } = useTranslation('components');
 
   const rotationKeybind = keybinds.find(
     (keybind) => keybind.action === 'os.ToggleRotationFriction'
@@ -19,16 +21,13 @@ export function FrictionControlsInfo() {
   return (
     <>
       <Text size={'md'} fw={'bold'}>
-        Friction controls:
+        {t('friction-controls-info.heading')}:
       </Text>
-      <Text>
-        Enable or disable rotation, zoom, and roll friction. If checked, applies friction
-        to camera movement.
-      </Text>
+      <Text>{t('friction-controls-info.description')}</Text>
       <Stack gap={'xs'}>
         {rotationKeybind && (
           <Group justify={'space-between'}>
-            <Text fw={'bold'}>Rotation:</Text>
+            <Text fw={'bold'}>{t('friction-controls.rotation-label')}:</Text>
             <KeybindButtons
               modifiers={rotationKeybind.modifiers}
               selectedKey={rotationKeybind.key}
@@ -37,7 +36,7 @@ export function FrictionControlsInfo() {
         )}
         {zoomKeybind && (
           <Group justify={'space-between'}>
-            <Text fw={'bold'}>Zoom:</Text>
+            <Text fw={'bold'}>{t('friction-controls.zoom-label')}:</Text>
             <KeybindButtons
               modifiers={zoomKeybind.modifiers}
               selectedKey={zoomKeybind.key}
@@ -46,7 +45,7 @@ export function FrictionControlsInfo() {
         )}
         {rollKeybind && (
           <Group justify={'space-between'}>
-            <Text fw={'bold'}>Roll:</Text>
+            <Text fw={'bold'}>{t('friction-controls.roll-label')}:</Text>
             <KeybindButtons
               modifiers={rollKeybind.modifiers}
               selectedKey={rollKeybind.key}

--- a/src/components/FrictionControls/FrictionControlsInfo.tsx
+++ b/src/components/FrictionControls/FrictionControlsInfo.tsx
@@ -21,9 +21,9 @@ export function FrictionControlsInfo() {
   return (
     <>
       <Text size={'md'} fw={'bold'}>
-        {t('friction-controls-info.heading')}:
+        {t('friction-controls.info.heading')}:
       </Text>
-      <Text>{t('friction-controls-info.description')}</Text>
+      <Text>{t('friction-controls.info.description')}</Text>
       <Stack gap={'xs'}>
         {rotationKeybind && (
           <Group justify={'space-between'}>

--- a/src/components/InfoBox/InfoBox.tsx
+++ b/src/components/InfoBox/InfoBox.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export function InfoBox({ children, w = 320 }: Props & PropsWithChildren) {
   const [opened, setOpened] = useState(false);
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'info-box' });
 
   return (
     <Popover
@@ -25,7 +25,7 @@ export function InfoBox({ children, w = 320 }: Props & PropsWithChildren) {
         <ActionIcon
           radius={'xl'}
           size={'xs'}
-          aria-label={t('info-box.aria-label')}
+          aria-label={t('aria-label')}
           onClick={() => setOpened(!opened)}
         >
           <InformationIcon />

--- a/src/components/InfoBox/InfoBox.tsx
+++ b/src/components/InfoBox/InfoBox.tsx
@@ -1,4 +1,5 @@
 import { PropsWithChildren, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ActionIcon, Popover } from '@mantine/core';
 
 import { InformationIcon } from '@/icons/icons';
@@ -9,6 +10,7 @@ interface Props {
 
 export function InfoBox({ children, w = 320 }: Props & PropsWithChildren) {
   const [opened, setOpened] = useState(false);
+  const { t } = useTranslation('components');
 
   return (
     <Popover
@@ -23,7 +25,7 @@ export function InfoBox({ children, w = 320 }: Props & PropsWithChildren) {
         <ActionIcon
           radius={'xl'}
           size={'xs'}
-          aria-label={'More information'}
+          aria-label={t('info-box.aria-label')}
           onClick={() => setOpened(!opened)}
         >
           <InformationIcon />

--- a/src/components/Input/NumericInput/NumericInput.tsx
+++ b/src/components/Input/NumericInput/NumericInput.tsx
@@ -44,7 +44,7 @@ export function NumericInput({
     setIsEditing,
     isEditing
   } = usePropListeningState<number | undefined>(value);
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'input.numeric-input' });
 
   const shouldClamp = props.clampBehavior === 'strict';
 
@@ -132,7 +132,7 @@ export function NumericInput({
       leftSection={
         isOutsideRange &&
         !isEditing && (
-          <Tooltip label={t('input.numeric-input.error-label', { min, max })}>
+          <Tooltip label={t('error-label', { min, max })}>
             <ThemeIcon color={'orange.4'} variant={'transparent'}>
               <WarningIcon size={IconSize.xs} />
             </ThemeIcon>
@@ -149,11 +149,7 @@ export function NumericInput({
           />
         )
       }
-      error={
-        isOutsideRange && isEditing
-          ? t('input.numeric-input.error-label', { min, max })
-          : undefined
-      }
+      error={isOutsideRange && isEditing ? t('error-label', { min, max }) : undefined}
       {...props}
       // TODO: Provide error on invalid input
     />

--- a/src/components/Input/NumericInput/NumericInput.tsx
+++ b/src/components/Input/NumericInput/NumericInput.tsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { NumberInput, NumberInputProps, ThemeIcon, Tooltip } from '@mantine/core';
 
 import { usePropListeningState } from '@/hooks/util';
@@ -43,6 +44,7 @@ export function NumericInput({
     setIsEditing,
     isEditing
   } = usePropListeningState<number | undefined>(value);
+  const { t } = useTranslation('components');
 
   const shouldClamp = props.clampBehavior === 'strict';
 
@@ -130,7 +132,7 @@ export function NumericInput({
       leftSection={
         isOutsideRange &&
         !isEditing && (
-          <Tooltip label={`Value outside range [${min}, ${max}]`}>
+          <Tooltip label={t('input.numeric-input.error-label', { min, max })}>
             <ThemeIcon color={'orange.4'} variant={'transparent'}>
               <WarningIcon size={IconSize.xs} />
             </ThemeIcon>
@@ -148,7 +150,9 @@ export function NumericInput({
         )
       }
       error={
-        isOutsideRange && isEditing ? `Value outside range [${min}, ${max}]` : undefined
+        isOutsideRange && isEditing
+          ? t('input.numeric-input.error-label', { min, max })
+          : undefined
       }
       {...props}
       // TODO: Provide error on invalid input

--- a/src/components/Input/NumericInput/StepControlButton.tsx
+++ b/src/components/Input/NumericInput/StepControlButton.tsx
@@ -36,7 +36,7 @@ export function StepControlButton({
     () => stepInterval.start(),
     stepHoldDelay
   );
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'input.step-control-button' });
   const onStepDone = useCallback((): void => {
     clearTimeout();
     if (stepInterval.active) {
@@ -91,9 +91,7 @@ export function StepControlButton({
       variant={'transparent'}
       tabIndex={tabIndex}
       aria-label={
-        direction === 'up'
-          ? t('input.step-control-button.aria-label.increment')
-          : t('input.step-control-button.aria-label.decrement')
+        direction === 'up' ? t('aria-label.increment') : t('aria-label.decrement')
       }
       {...props}
     >

--- a/src/components/Input/NumericInput/StepControlButton.tsx
+++ b/src/components/Input/NumericInput/StepControlButton.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ActionIcon, ActionIconProps } from '@mantine/core';
 import { useInterval, useTimeout } from '@mantine/hooks';
 
@@ -35,7 +36,7 @@ export function StepControlButton({
     () => stepInterval.start(),
     stepHoldDelay
   );
-
+  const { t } = useTranslation('components');
   const onStepDone = useCallback((): void => {
     clearTimeout();
     if (stepInterval.active) {
@@ -89,7 +90,11 @@ export function StepControlButton({
       size={'xs'}
       variant={'transparent'}
       tabIndex={tabIndex}
-      aria-label={direction === 'up' ? 'Increment value' : 'Decrement value'}
+      aria-label={
+        direction === 'up'
+          ? t('input.step-control-button.aria-label.increment')
+          : t('input.step-control-button.aria-label.decrement')
+      }
       {...props}
     >
       {direction === 'up' ? <ChevronUpIcon /> : <ChevronDownIcon />}

--- a/src/components/NodeNavigationButton/NodeNavigationButton.tsx
+++ b/src/components/NodeNavigationButton/NodeNavigationButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import {
   ActionIcon,
   ActionIconProps,
@@ -76,6 +77,7 @@ export function NodeNavigationButton({
   disabled
 }: NodeNavigationButtonProps) {
   const luaApi = useOpenSpaceApi();
+  const { t } = useTranslation('components', { keyPrefix: 'node-navigation-button' });
 
   function focus(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
     if (!event.shiftKey) {
@@ -150,59 +152,41 @@ export function NodeNavigationButton({
   switch (type) {
     case NavigationType.Jump:
       content.onClick = fadeTo;
-      content.title = 'Jump to';
+      content.title = t('jump.title');
       content.icon = <LightningFlashIcon />;
-      content.tooltip = 'Teleport to object using a fade transition';
+      content.tooltip = t('jump.tooltip');
       break;
     case NavigationType.JumpGeo:
       content.onClick = jumpToGeo;
-      content.title = 'Jump to Geo';
+      content.title = t('jump-geo.title');
       content.icon = <LightningFlashIcon />;
-      content.tooltip = 'Teleport to position using a fade transition';
+      content.tooltip = t('jump-geo.tooltip');
       break;
     case NavigationType.Focus:
       content.onClick = focus;
-      content.title = 'Focus';
+      content.title = t('focus.title');
       content.icon = <FocusIcon />;
-      content.tooltip = (
-        <span>
-          Focus the object (set as anchor). Hold <Kbd>Shift</Kbd> when clicking to focus
-          without retargeting
-        </span>
-      );
+      content.tooltip = <Trans t={t} i18nKey={'focus.tooltip'} components={[<Kbd />]} />;
       break;
     case NavigationType.Fly:
       content.onClick = flyTo;
-      content.title = 'Fly to';
+      content.title = t('fly.title');
       content.icon = <AirplaneIcon />;
-      content.tooltip = (
-        <span>
-          Trigger a flight to the object. Hold <Kbd>Shift</Kbd> when clicking to instantly
-          teleport/jump
-        </span>
-      );
+      content.tooltip = <Trans t={t} i18nKey={'fly.tooltip'} components={[<Kbd />]} />;
       break;
     case NavigationType.FlyGeo:
       content.onClick = flyToGeo;
-      content.title = 'Fly to Geo';
+      content.title = t('fly-geo.title');
       content.icon = <AirplaneIcon />;
       content.tooltip = (
-        <span>
-          Trigger a flight to the position. Hold <Kbd>Shift</Kbd> when clicking to
-          instantly teleport/jump
-        </span>
+        <Trans t={t} i18nKey={'fly-geo.tooltip'} components={[<Kbd />]} />
       );
       break;
     case NavigationType.Frame:
       content.onClick = zoomToFocus;
-      content.title = 'Zoom to / Frame';
+      content.title = t('frame.title');
       content.icon = <FrameFocusIcon />;
-      content.tooltip = (
-        <span>
-          Frame the object by moving the camera in a straigt line and rotate towards it.
-          Hold <Kbd>Shift</Kbd> when clicking to do it instantaneously
-        </span>
-      );
+      content.tooltip = <Trans t={t} i18nKey={'frame.tooltip'} components={[<Kbd />]} />;
       break;
 
     default:

--- a/src/components/Property/PropertyLabel.tsx
+++ b/src/components/Property/PropertyLabel.tsx
@@ -1,4 +1,5 @@
 import { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Text, Tooltip } from '@mantine/core';
 
 import CopyUriButton from '@/components/CopyUriButton/CopyUriButton';
@@ -13,6 +14,8 @@ interface Props {
 }
 
 export function PropertyLabel({ name, description, uri, readOnly = false }: Props) {
+  const { t } = useTranslation('components');
+
   return (
     <Label
       name={
@@ -22,10 +25,10 @@ export function PropertyLabel({ name, description, uri, readOnly = false }: Prop
             <Tooltip
               maw={200}
               multiline
-              label={`This property is read-only, meaning that it's not intended to be changed.`}
+              label={t('property.property-label.tooltip-label')}
             >
               <Text span ml={'xs'} size={'xs'} c={'dimmed'}>
-                (Read-only)
+                {t('property.property-label.label')}
               </Text>
             </Tooltip>
           )}

--- a/src/components/Property/PropertyLabel.tsx
+++ b/src/components/Property/PropertyLabel.tsx
@@ -22,9 +22,9 @@ export function PropertyLabel({ name, description, uri, readOnly = false }: Prop
         <>
           {name}
           {readOnly && (
-            <Tooltip maw={200} multiline label={t('tooltip-label')}>
+            <Tooltip maw={200} multiline label={t('read-only-tooltip')}>
               <Text span ml={'xs'} size={'xs'} c={'dimmed'}>
-                {t('label')}
+                {`(${t('read-only-label')})`}
               </Text>
             </Tooltip>
           )}

--- a/src/components/Property/PropertyLabel.tsx
+++ b/src/components/Property/PropertyLabel.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 export function PropertyLabel({ name, description, uri, readOnly = false }: Props) {
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'property.property-label' });
 
   return (
     <Label
@@ -22,13 +22,9 @@ export function PropertyLabel({ name, description, uri, readOnly = false }: Prop
         <>
           {name}
           {readOnly && (
-            <Tooltip
-              maw={200}
-              multiline
-              label={t('property.property-label.tooltip-label')}
-            >
+            <Tooltip maw={200} multiline label={t('tooltip-label')}>
               <Text span ml={'xs'} size={'xs'} c={'dimmed'}>
-                {t('property.property-label.label')}
+                {t('label')}
               </Text>
             </Tooltip>
           )}

--- a/src/components/Property/Types/ListProperty/DoubleListProperty.tsx
+++ b/src/components/Property/Types/ListProperty/DoubleListProperty.tsx
@@ -1,9 +1,12 @@
+import { useTranslation } from 'react-i18next';
+
 import { Pills } from '@/components/Pills/Pills';
 import { PropertyProps } from '@/components/Property/types';
 import { useProperty } from '@/hooks/properties';
 
 export function DoubleListProperty({ uri, readOnly }: PropertyProps) {
   const [value, setValue] = useProperty('DoubleListProperty', uri);
+  const { t } = useTranslation('components');
 
   if (value === undefined) {
     return <></>;
@@ -17,7 +20,7 @@ export function DoubleListProperty({ uri, readOnly }: PropertyProps) {
     <Pills
       value={value.map((v) => v.toString())}
       setValue={setValueString}
-      placeHolderText={'number1, number2, ...'}
+      placeHolderText={t('property.list-property.double-list-placeholder-text')}
       disabled={readOnly}
     />
   );

--- a/src/components/Property/Types/ListProperty/DoubleListProperty.tsx
+++ b/src/components/Property/Types/ListProperty/DoubleListProperty.tsx
@@ -6,7 +6,7 @@ import { useProperty } from '@/hooks/properties';
 
 export function DoubleListProperty({ uri, readOnly }: PropertyProps) {
   const [value, setValue] = useProperty('DoubleListProperty', uri);
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'property.list-property' });
 
   if (value === undefined) {
     return <></>;
@@ -20,7 +20,7 @@ export function DoubleListProperty({ uri, readOnly }: PropertyProps) {
     <Pills
       value={value.map((v) => v.toString())}
       setValue={setValueString}
-      placeHolderText={t('property.list-property.double-list-placeholder-text')}
+      placeHolderText={t('double-list-placeholder-text')}
       disabled={readOnly}
     />
   );

--- a/src/components/Property/Types/ListProperty/IntListProperty.tsx
+++ b/src/components/Property/Types/ListProperty/IntListProperty.tsx
@@ -6,7 +6,7 @@ import { useProperty } from '@/hooks/properties';
 
 export function IntListProperty({ uri, readOnly }: PropertyProps) {
   const [value, setValue] = useProperty('IntListProperty', uri);
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'property.list-property' });
 
   if (value === undefined) {
     return <></>;
@@ -20,7 +20,7 @@ export function IntListProperty({ uri, readOnly }: PropertyProps) {
     <Pills
       value={value.map((value) => value.toString())}
       setValue={setValueFromString}
-      placeHolderText={t('property.list-property.int-list-placeholder-text')}
+      placeHolderText={t('int-list-placeholder-text')}
       disabled={readOnly}
     />
   );

--- a/src/components/Property/Types/ListProperty/IntListProperty.tsx
+++ b/src/components/Property/Types/ListProperty/IntListProperty.tsx
@@ -1,9 +1,12 @@
+import { useTranslation } from 'react-i18next';
+
 import { Pills } from '@/components/Pills/Pills';
 import { PropertyProps } from '@/components/Property/types';
 import { useProperty } from '@/hooks/properties';
 
 export function IntListProperty({ uri, readOnly }: PropertyProps) {
   const [value, setValue] = useProperty('IntListProperty', uri);
+  const { t } = useTranslation('components');
 
   if (value === undefined) {
     return <></>;
@@ -17,7 +20,7 @@ export function IntListProperty({ uri, readOnly }: PropertyProps) {
     <Pills
       value={value.map((value) => value.toString())}
       setValue={setValueFromString}
-      placeHolderText={'integer1, integer2, ...'}
+      placeHolderText={t('property.list-property.int-list-placeholder-text')}
       disabled={readOnly}
     />
   );

--- a/src/components/Property/Types/ListProperty/StringListProperty.tsx
+++ b/src/components/Property/Types/ListProperty/StringListProperty.tsx
@@ -1,9 +1,12 @@
+import { useTranslation } from 'react-i18next';
+
 import { Pills } from '@/components/Pills/Pills';
 import { PropertyProps } from '@/components/Property/types';
 import { useProperty } from '@/hooks/properties';
 
 export function StringListProperty({ uri, readOnly }: PropertyProps) {
   const [value, setValue] = useProperty('StringListProperty', uri);
+  const { t } = useTranslation('components');
 
   if (value === undefined) {
     return <></>;
@@ -13,7 +16,7 @@ export function StringListProperty({ uri, readOnly }: PropertyProps) {
     <Pills
       value={value}
       setValue={setValue}
-      placeHolderText={'item1, item2, ...'}
+      placeHolderText={t('property.list-property.string-list-placeholder-text')}
       disabled={readOnly}
     />
   );

--- a/src/components/Property/Types/ListProperty/StringListProperty.tsx
+++ b/src/components/Property/Types/ListProperty/StringListProperty.tsx
@@ -6,7 +6,7 @@ import { useProperty } from '@/hooks/properties';
 
 export function StringListProperty({ uri, readOnly }: PropertyProps) {
   const [value, setValue] = useProperty('StringListProperty', uri);
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'property.list-property' });
 
   if (value === undefined) {
     return <></>;
@@ -16,7 +16,7 @@ export function StringListProperty({ uri, readOnly }: PropertyProps) {
     <Pills
       value={value}
       setValue={setValue}
-      placeHolderText={t('property.list-property.string-list-placeholder-text')}
+      placeHolderText={t('string-list-placeholder-text')}
       disabled={readOnly}
     />
   );

--- a/src/components/Property/Types/OptionProperty.tsx
+++ b/src/components/Property/Types/OptionProperty.tsx
@@ -6,7 +6,7 @@ import { useProperty } from '@/hooks/properties';
 
 export function OptionProperty({ uri, readOnly }: PropertyProps) {
   const [value, setValue, meta] = useProperty('OptionProperty', uri);
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'property.option-property' });
 
   if (!meta || value === undefined || !meta.additionalData) {
     return <></>;
@@ -19,8 +19,8 @@ export function OptionProperty({ uri, readOnly }: PropertyProps) {
   if (!options) {
     return (
       <Select
-        aria-label={t('property.option-property.aria-label', { guiName: meta.guiName })}
-        placeholder={t('property.option-property.placeholder.no-options')}
+        aria-label={t('aria-label', { guiName: meta.guiName })}
+        placeholder={t('placeholder.no-options')}
         disabled
       />
     );
@@ -28,8 +28,8 @@ export function OptionProperty({ uri, readOnly }: PropertyProps) {
 
   return (
     <Select
-      aria-label={t('property.option-property.aria-label', { guiName: meta.guiName })}
-      placeholder={t('property.option-property.placeholder.options')}
+      aria-label={t('aria-label', { guiName: meta.guiName })}
+      placeholder={t('placeholder.options')}
       disabled={readOnly}
       // For each entry in the options object, the numeric value is the key, and the
       // label is the value

--- a/src/components/Property/Types/OptionProperty.tsx
+++ b/src/components/Property/Types/OptionProperty.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Select } from '@mantine/core';
 
 import { PropertyProps } from '@/components/Property/types';
@@ -5,6 +6,7 @@ import { useProperty } from '@/hooks/properties';
 
 export function OptionProperty({ uri, readOnly }: PropertyProps) {
   const [value, setValue, meta] = useProperty('OptionProperty', uri);
+  const { t } = useTranslation('components');
 
   if (!meta || value === undefined || !meta.additionalData) {
     return <></>;
@@ -17,8 +19,8 @@ export function OptionProperty({ uri, readOnly }: PropertyProps) {
   if (!options) {
     return (
       <Select
-        aria-label={`${meta.guiName} option input`}
-        placeholder={'No options were loaded'}
+        aria-label={t('property.option-property.aria-label', { guiName: meta.guiName })}
+        placeholder={t('property.option-property.placeholder.no-options')}
         disabled
       />
     );
@@ -26,8 +28,8 @@ export function OptionProperty({ uri, readOnly }: PropertyProps) {
 
   return (
     <Select
-      aria-label={`${meta.guiName} option input`}
-      placeholder={'Choose an option'}
+      aria-label={t('property.option-property.aria-label', { guiName: meta.guiName })}
+      placeholder={t('property.option-property.placeholder.options')}
       disabled={readOnly}
       // For each entry in the options object, the numeric value is the key, and the
       // label is the value

--- a/src/components/Property/Types/SelectionProperty.tsx
+++ b/src/components/Property/Types/SelectionProperty.tsx
@@ -10,7 +10,9 @@ export function SelectionProperty({ uri, readOnly }: PropertyProps) {
   const { value: currentValue, setValue: setCurrentValue } = usePropListeningState<
     string[] | undefined
   >(value);
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', {
+    keyPrefix: 'property.selection-property'
+  });
 
   if (!value || !meta || currentValue === undefined) {
     return <></>;
@@ -25,14 +27,12 @@ export function SelectionProperty({ uri, readOnly }: PropertyProps) {
 
   return (
     <MultiSelect
-      aria-label={t('property.selection-property.aria-label', { guiName: meta.guiName })}
+      aria-label={t('aria-label', { guiName: meta.guiName })}
       disabled={readOnly}
       data={options}
       value={currentValue}
       onChange={handleChange}
-      placeholder={
-        value.length === 0 ? t('property.selection-property.placeholder-empty-field') : ''
-      }
+      placeholder={value.length === 0 ? t('placeholder-empty-field') : ''}
       searchable
       clearable
     />

--- a/src/components/Property/Types/SelectionProperty.tsx
+++ b/src/components/Property/Types/SelectionProperty.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { MultiSelect } from '@mantine/core';
 
 import { PropertyProps } from '@/components/Property/types';
@@ -9,6 +10,7 @@ export function SelectionProperty({ uri, readOnly }: PropertyProps) {
   const { value: currentValue, setValue: setCurrentValue } = usePropListeningState<
     string[] | undefined
   >(value);
+  const { t } = useTranslation('components');
 
   if (!value || !meta || currentValue === undefined) {
     return <></>;
@@ -23,12 +25,14 @@ export function SelectionProperty({ uri, readOnly }: PropertyProps) {
 
   return (
     <MultiSelect
-      aria-label={`${meta.guiName} multi-select`}
+      aria-label={t('property.selection-property.aria-label', { guiName: meta.guiName })}
       disabled={readOnly}
       data={options}
       value={currentValue}
       onChange={handleChange}
-      placeholder={value.length === 0 ? 'No selection' : ''}
+      placeholder={
+        value.length === 0 ? t('property.selection-property.placeholder-empty-field') : ''
+      }
       searchable
       clearable
     />

--- a/src/components/Property/Types/StringProperty.tsx
+++ b/src/components/Property/Types/StringProperty.tsx
@@ -7,7 +7,7 @@ import { useProperty } from '@/hooks/properties';
 
 export function StringProperty({ uri, readOnly }: PropertyProps) {
   const [value, setValue, meta] = useProperty('StringProperty', uri);
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'property.string-property' });
 
   if (value === undefined || !meta) {
     return <></>;
@@ -24,7 +24,7 @@ export function StringProperty({ uri, readOnly }: PropertyProps) {
     <StringInput
       onEnter={setValue}
       value={value}
-      aria-label={t('property.list-property.string-list-placeholder-text', {
+      aria-label={t('aria-label', {
         guiName: meta.guiName
       })}
     />

--- a/src/components/Property/Types/StringProperty.tsx
+++ b/src/components/Property/Types/StringProperty.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Paper, Text } from '@mantine/core';
 
 import { StringInput } from '@/components/Input/StringInput';
@@ -6,6 +7,7 @@ import { useProperty } from '@/hooks/properties';
 
 export function StringProperty({ uri, readOnly }: PropertyProps) {
   const [value, setValue, meta] = useProperty('StringProperty', uri);
+  const { t } = useTranslation('components');
 
   if (value === undefined || !meta) {
     return <></>;
@@ -19,6 +21,12 @@ export function StringProperty({ uri, readOnly }: PropertyProps) {
     );
   }
   return (
-    <StringInput onEnter={setValue} value={value} aria-label={`${meta.guiName} input`} />
+    <StringInput
+      onEnter={setValue}
+      value={value}
+      aria-label={t('property.list-property.string-list-placeholder-text', {
+        guiName: meta.guiName
+      })}
+    />
   );
 }

--- a/src/components/ResizeableContent/ResizeableContent.tsx
+++ b/src/components/ResizeableContent/ResizeableContent.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState
 } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ActionIcon, Box, BoxComponentProps } from '@mantine/core';
 
 import { DragHandleIcon } from '@/icons/icons';
@@ -26,6 +27,7 @@ export function ResizeableContent({
 }: Props) {
   const [height, setHeight] = useState(defaultHeight);
   const { pointerEvents: windowPointer } = useWindowSize();
+  const { t } = useTranslation('components');
 
   const contentRef = useRef<HTMLDivElement>(null);
   const resizerRef = useRef<HTMLDivElement>(null);
@@ -127,7 +129,7 @@ export function ResizeableContent({
           }}
           size={'xs'}
           radius={0}
-          aria-label={'Resize window (keyboard control not supported)'}
+          aria-label={t('resizeable-content.aria-label')}
         >
           <DragHandleIcon size={IconSize.xs} />
         </ActionIcon>

--- a/src/components/ResizeableContent/ResizeableContent.tsx
+++ b/src/components/ResizeableContent/ResizeableContent.tsx
@@ -27,7 +27,7 @@ export function ResizeableContent({
 }: Props) {
   const [height, setHeight] = useState(defaultHeight);
   const { pointerEvents: windowPointer } = useWindowSize();
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'resizeable-content' });
 
   const contentRef = useRef<HTMLDivElement>(null);
   const resizerRef = useRef<HTMLDivElement>(null);
@@ -129,7 +129,7 @@ export function ResizeableContent({
           }}
           size={'xs'}
           radius={0}
-          aria-label={t('resizeable-content.aria-label')}
+          aria-label={t('aria-label')}
         >
           <DragHandleIcon size={IconSize.xs} />
         </ActionIcon>

--- a/src/components/SettingsPopout/SettingsPopout.tsx
+++ b/src/components/SettingsPopout/SettingsPopout.tsx
@@ -1,4 +1,5 @@
 import { PropsWithChildren } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ActionIcon, FloatingPosition, MantineStyleProps, Menu } from '@mantine/core';
 
 import { SettingsIcon } from '@/icons/icons';
@@ -16,6 +17,8 @@ export function SettingsPopout({
   children,
   ...styleProps
 }: Props) {
+  const { t } = useTranslation('components');
+
   return (
     <Menu
       position={position ?? 'right-start'}
@@ -24,7 +27,7 @@ export function SettingsPopout({
       withArrow
     >
       <Menu.Target>
-        <ActionIcon {...styleProps} aria-label={'Open settings'}>
+        <ActionIcon {...styleProps} aria-label={t('settings-popout.aria-label')}>
           <SettingsIcon />
         </ActionIcon>
       </Menu.Target>

--- a/src/components/SettingsPopout/SettingsPopout.tsx
+++ b/src/components/SettingsPopout/SettingsPopout.tsx
@@ -17,7 +17,7 @@ export function SettingsPopout({
   children,
   ...styleProps
 }: Props) {
-  const { t } = useTranslation('components');
+  const { t } = useTranslation('components', { keyPrefix: 'settings-popout' });
 
   return (
     <Menu
@@ -27,7 +27,7 @@ export function SettingsPopout({
       withArrow
     >
       <Menu.Target>
-        <ActionIcon {...styleProps} aria-label={t('settings-popout.aria-label')}>
+        <ActionIcon {...styleProps} aria-label={t('aria-label')}>
           <SettingsIcon />
         </ActionIcon>
       </Menu.Target>

--- a/src/icons/icons.tsx
+++ b/src/icons/icons.tsx
@@ -87,7 +87,8 @@ export {
   MdWater as WaterIcon,
   MdZoomIn as ZoomInIcon,
   MdZoomOut as ZoomOutIcon,
-  MdZoomOutMap as ZoomOutMapIcon} from 'react-icons/md';
+  MdZoomOutMap as ZoomOutMapIcon
+} from 'react-icons/md';
 export {
   PiBookOpenText as BookIcon,
   PiMouseLeftClickThin as LeftClickMouseIcon,

--- a/src/localization/config.tsx
+++ b/src/localization/config.tsx
@@ -8,7 +8,7 @@ import { LanguageInfo } from '@/types/types';
 // Key should match the IEFT language code: https://en.wikipedia.org/wiki/IETF_language_tag
 // See available icons at https://catamphetamine.gitlab.io/country-flag-icons/3x2/index.html
 export const SupportedLanguages: Record<string, LanguageInfo> = {
-  en: { language: 'English', icon: <US width={20} /> },
+  en: { language: 'English-US', icon: <US width={20} /> },
   sv: { language: 'Swedish', icon: <SE width={20} /> }
 };
 
@@ -21,6 +21,8 @@ i18n
     // Fallback when a locale translation is missing
     fallbackLng: 'en',
     supportedLngs: Object.keys(SupportedLanguages),
+    ns: ['common'],
+    defaultNS: false,
     debug: true,
     interpolation: {
       // React already escapes any code in translation messages, safguarding against XSS

--- a/src/localization/resources.ts
+++ b/src/localization/resources.ts
@@ -1,0 +1,13 @@
+import components from '@/public/locales/en/components.json';
+
+/**
+ * This object in combination with `i18next.d.ts` enables intellisense and syntax
+ * highlighting when accessing the translation units, e.g., useTranslation('components');
+ */
+export const resources = {
+  en: {
+    components: components
+  }
+} as const;
+
+export type Resources = typeof resources;

--- a/src/panels/Menu/TopMenuBar/Menus/LocaleSwitcher.tsx
+++ b/src/panels/Menu/TopMenuBar/Menus/LocaleSwitcher.tsx
@@ -8,12 +8,12 @@ import { IconSize } from '@/types/enums';
 import { TopBarMenuWrapper } from '../TopBarMenuWrapper';
 
 export function LocaleSwitcher() {
-  const { i18n } = useTranslation('settings');
+  const { i18n } = useTranslation();
 
   function languageIcon(): React.JSX.Element {
-    const { resolvedLanguage } = i18n;
-    return resolvedLanguage ? (
-      SupportedLanguages[resolvedLanguage].icon
+    const { language } = i18n;
+    return language ? (
+      SupportedLanguages[language].icon
     ) : (
       <LanguageIcon size={IconSize.sm} />
     );

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -1,0 +1,9 @@
+import 'i18next';
+
+import type { Resources } from '@/localization/resources';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    resources: Resources['en'];
+  }
+}


### PR DESCRIPTION
Added localization for all components that had some form of text. However, I did not do it for thrown errors, which should only occur during development, e.g., `throw Error('useSearchResultProvider must be used within a SearchResultProvider');`
But then I ended up not doing it for any thrown errors, do we want it in those places anyway?

Do check the JSON file structure and see what you think of the nesting. In some places, e.g., properties are grouped under `property`, while others, for example, `color-edit` and `color-picker` are two separate entries. We should discuss when and if we should group them. 

The order of the entries is alphabetical at the top-level, i.e., `about`, `collapsable-header` etc. The internal structure is either top to bottom or grouped by some internal hierarchy for that specific component. 

Did not do anything for `Pills.tsx` since that one has an aria-label using `name` that is deprecated? Something we want to look at. 

I also noticed that `FilterlistGrid.tsx` is an empty file, and should be deleted?
