### PR TITLE
Refactor keybinds panel

### DIFF
--- a/src/panels/KeybindsPanel/KeybindButtons.tsx
+++ b/src/panels/KeybindsPanel/KeybindButtons.tsx
@@ -24,7 +24,7 @@ export function KeybindButtons({
   const allKeys = [...modifiers, displayKey].filter((kbd) => kbd);
 
   return (
-    <Group wrap={'nowrap'} {...styleProps}>
+    <Group wrap={'nowrap'} gap={'xs'} {...styleProps}>
       {allKeys.map((kbd, i) => (
         <Fragment key={kbd}>
           {i !== 0 && <Text c={'white'}> + </Text>}

--- a/src/panels/KeybindsPanel/KeybindInfo.tsx
+++ b/src/panels/KeybindsPanel/KeybindInfo.tsx
@@ -1,4 +1,4 @@
-import { Badge, Code, Group, Paper, Table, Title } from '@mantine/core';
+import { Badge, Code, Group, Paper, Table, Text } from '@mantine/core';
 
 import { CopyToClipboardButton } from '@/components/CopyToClipboardButton/CopyToClipboardButton';
 import { Action } from '@/types/types';
@@ -9,10 +9,10 @@ interface Props {
 
 export function KeybindInfo({ selectedAction }: Props) {
   return (
-    <Paper key={selectedAction.identifier} p={'md'}>
-      <Title order={4} mb={'md'}>
+    <Paper key={selectedAction.identifier} p={'sm'}>
+      <Text ml={'xs'} mb={'xs'} fw={'bold'}>
         {selectedAction.name}
-      </Title>
+      </Text>
       <Table>
         <Table.Tbody>
           <Table.Tr>

--- a/src/panels/KeybindsPanel/KeybindInfo.tsx
+++ b/src/panels/KeybindsPanel/KeybindInfo.tsx
@@ -1,10 +1,12 @@
-import { Badge, Code, Paper, Table, Title } from '@mantine/core';
+import { Badge, Code, Group, Paper, Table, Title } from '@mantine/core';
 
+import { CopyToClipboardButton } from '@/components/CopyToClipboardButton/CopyToClipboardButton';
 import { Action } from '@/types/types';
 
 interface Props {
   selectedAction: Action;
 }
+
 export function KeybindInfo({ selectedAction }: Props) {
   return (
     <Paper key={selectedAction.identifier} p={'md'}>
@@ -36,7 +38,12 @@ export function KeybindInfo({ selectedAction }: Props) {
           <Table.Tr>
             <Table.Td>Identifier:</Table.Td>
             <Table.Td>
-              <Code>{selectedAction.identifier}</Code>
+              <Group gap={'xs'} wrap={'nowrap'}>
+                <Code style={{ wordBreak: 'break-word' }}>
+                  {selectedAction.identifier}
+                </Code>
+                <CopyToClipboardButton value={selectedAction.identifier} />
+              </Group>
             </Table.Td>
           </Table.Tr>
         </Table.Tbody>

--- a/src/panels/KeybindsPanel/KeybindInfo.tsx
+++ b/src/panels/KeybindsPanel/KeybindInfo.tsx
@@ -4,50 +4,38 @@ import { CopyToClipboardButton } from '@/components/CopyToClipboardButton/CopyTo
 import { Action } from '@/types/types';
 
 interface Props {
-  selectedAction: Action;
+  action: Action;
 }
 
-export function KeybindInfo({ selectedAction }: Props) {
+export function KeybindInfo({ action }: Props) {
   return (
-    <Paper key={selectedAction.identifier} p={'sm'}>
-      <Text ml={'xs'} mb={'xs'} fw={'bold'}>
-        {selectedAction.name}
+    <Paper key={action.identifier} p={'sm'}>
+      <Text ml={'xs'} mb={2} fw={'bold'}>
+        {action.name}
       </Text>
-      <Table>
-        <Table.Tbody>
-          <Table.Tr>
-            <Table.Td>Description:</Table.Td>
-            <Table.Td>{selectedAction.documentation}</Table.Td>
-          </Table.Tr>
-          <Table.Tr>
-            <Table.Td>Is Local:</Table.Td>
-            <Table.Td>
-              {selectedAction.isLocal ? (
+      <Table
+        data={{
+          body: [
+            ['Info:', action.documentation],
+            [
+              'Is Local:',
+              action.isLocal ? (
                 <Badge variant={'filled'}>Yes</Badge>
               ) : (
                 <Badge variant={'outline'}>No</Badge>
-              )}
-            </Table.Td>
-          </Table.Tr>
-          <Table.Tr>
-            <Table.Td>GUI Path:</Table.Td>
-            <Table.Td>
-              <Code>{selectedAction.guiPath}</Code>
-            </Table.Td>
-          </Table.Tr>
-          <Table.Tr>
-            <Table.Td>Identifier:</Table.Td>
-            <Table.Td>
+              )
+            ],
+            ['GUI Path:', <Code>{action.guiPath}</Code>],
+            [
+              'Identifier:',
               <Group gap={'xs'} wrap={'nowrap'}>
-                <Code style={{ wordBreak: 'break-word' }}>
-                  {selectedAction.identifier}
-                </Code>
-                <CopyToClipboardButton value={selectedAction.identifier} />
+                <Code style={{ wordBreak: 'break-word' }}>{action.identifier}</Code>
+                <CopyToClipboardButton value={action.identifier} />
               </Group>
-            </Table.Td>
-          </Table.Tr>
-        </Table.Tbody>
-      </Table>
+            ]
+          ]
+        }}
+      />
     </Paper>
   );
 }

--- a/src/panels/KeybindsPanel/KeybindInfo.tsx
+++ b/src/panels/KeybindsPanel/KeybindInfo.tsx
@@ -33,6 +33,12 @@ export function KeybindInfo({ selectedAction }: Props) {
               <Code>{selectedAction.guiPath}</Code>
             </Table.Td>
           </Table.Tr>
+          <Table.Tr>
+            <Table.Td>Identifier:</Table.Td>
+            <Table.Td>
+              <Code>{selectedAction.identifier}</Code>
+            </Table.Td>
+          </Table.Tr>
         </Table.Tbody>
       </Table>
     </Paper>

--- a/src/panels/KeybindsPanel/KeybindsPanel.tsx
+++ b/src/panels/KeybindsPanel/KeybindsPanel.tsx
@@ -1,13 +1,19 @@
 import { Box, Tabs } from '@mantine/core';
+import { useElementSize } from '@mantine/hooks';
+
+import { useWindowSize } from '@/windowmanagement/Window/hooks';
 
 import { KeyboardLayout } from './KeyboardLayout';
 import { ListLayout } from './ListLayout';
 
 export function KeybindsPanel() {
+  const { height: windowHeight } = useWindowSize();
+  const { ref, height: tabsHeight } = useElementSize();
+
   return (
     <Box>
       <Tabs radius={'md'} defaultValue={'keyboardLayout'}>
-        <Tabs.List>
+        <Tabs.List ref={ref}>
           <Tabs.Tab value={'keyboardLayout'}>Keyboard View</Tabs.Tab>
           <Tabs.Tab value={'listLayout'}>List View</Tabs.Tab>
         </Tabs.List>
@@ -16,7 +22,7 @@ export function KeybindsPanel() {
           <KeyboardLayout />
         </Tabs.Panel>
         <Tabs.Panel value={'listLayout'}>
-          <ListLayout />
+          <ListLayout height={windowHeight - tabsHeight} />
         </Tabs.Panel>
       </Tabs>
     </Box>

--- a/src/panels/KeybindsPanel/KeybindsPanel.tsx
+++ b/src/panels/KeybindsPanel/KeybindsPanel.tsx
@@ -1,19 +1,13 @@
 import { Box, Tabs } from '@mantine/core';
-import { useElementSize } from '@mantine/hooks';
-
-import { useWindowSize } from '@/windowmanagement/Window/hooks';
 
 import { KeyboardLayout } from './KeyboardLayout';
 import { ListLayout } from './ListLayout';
 
 export function KeybindsPanel() {
-  const { height: windowHeight } = useWindowSize();
-  const { ref, height: tabsHeight } = useElementSize();
-
   return (
     <Box>
       <Tabs radius={'md'} defaultValue={'keyboardLayout'}>
-        <Tabs.List ref={ref}>
+        <Tabs.List>
           <Tabs.Tab value={'keyboardLayout'}>Keyboard View</Tabs.Tab>
           <Tabs.Tab value={'listLayout'}>List View</Tabs.Tab>
         </Tabs.List>
@@ -21,7 +15,7 @@ export function KeybindsPanel() {
         <Tabs.Panel value={'keyboardLayout'}>
           <KeyboardLayout />
         </Tabs.Panel>
-        <Tabs.Panel value={'listLayout'} h={windowHeight - tabsHeight}>
+        <Tabs.Panel value={'listLayout'}>
           <ListLayout />
         </Tabs.Panel>
       </Tabs>

--- a/src/panels/KeybindsPanel/KeybindsPanel.tsx
+++ b/src/panels/KeybindsPanel/KeybindsPanel.tsx
@@ -1,4 +1,4 @@
-import { Container, Tabs } from '@mantine/core';
+import { Box, Tabs } from '@mantine/core';
 import { useElementSize } from '@mantine/hooks';
 
 import { useWindowSize } from '@/windowmanagement/Window/hooks';
@@ -11,8 +11,8 @@ export function KeybindsPanel() {
   const { ref, height: tabsHeight } = useElementSize();
 
   return (
-    <Container fluid>
-      <Tabs variant={'outline'} radius={'md'} defaultValue={'keyboardLayout'}>
+    <Box>
+      <Tabs radius={'md'} defaultValue={'keyboardLayout'}>
         <Tabs.List ref={ref}>
           <Tabs.Tab value={'keyboardLayout'}>Keyboard View</Tabs.Tab>
           <Tabs.Tab value={'listLayout'}>List View</Tabs.Tab>
@@ -25,6 +25,6 @@ export function KeybindsPanel() {
           <ListLayout />
         </Tabs.Panel>
       </Tabs>
-    </Container>
+    </Box>
   );
 }

--- a/src/panels/KeybindsPanel/KeyboardLayout.tsx
+++ b/src/panels/KeybindsPanel/KeyboardLayout.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Container, Divider, Grid, Group, Text, Title } from '@mantine/core';
+import { Container, Divider, Grid, Group, Stack, Text, Title } from '@mantine/core';
 
 import { Action } from '@/types/types';
 
@@ -14,8 +14,7 @@ export function KeyboardLayout() {
 
   const hasSelectedKeys = selectedKey !== '' || activeModifiers.length > 0;
   return (
-    <Container maw={'none'} pt={'xs'}>
-      <Title order={2}>Keybinds</Title>
+    <Container maw={'none'}>
       <FullKeyboard
         setSelectedActions={setSelectedActions}
         setActiveModifiers={setActiveModifiers}
@@ -23,32 +22,32 @@ export function KeyboardLayout() {
         selectedKey={selectedKey}
         activeModifiers={activeModifiers}
       />
-      <Group my={'md'}>
-        <Text size={'lg'} fw={500}>
-          Selected keybind:
-        </Text>
-        <KeybindButtons selectedKey={selectedKey} modifiers={activeModifiers} />
+      <Group align={'top'}>
+        <Stack>
+          <Title order={2}>Selected keybind:</Title>
+          <KeybindButtons selectedKey={selectedKey} modifiers={activeModifiers} />
+        </Stack>
+        <Divider orientation={'vertical'} mx={'xs'} />
+        <Stack flex={1}>
+          <Title order={2}>Mapped actions:</Title>
+          {selectedActions.length > 0 ? (
+            <Grid mx={'xs'}>
+              {selectedActions.map((selectedAction) => (
+                <KeybindInfo
+                  key={selectedAction.identifier}
+                  selectedAction={selectedAction}
+                />
+              ))}
+            </Grid>
+          ) : (
+            <Text>
+              {hasSelectedKeys
+                ? 'No action is associated with this keybind.'
+                : 'No key selected. Select a key to see its action.'}
+            </Text>
+          )}
+        </Stack>
       </Group>
-      <Divider />
-      <Title order={3} my={'md'}>
-        Mapped actions
-      </Title>
-      {selectedActions.length > 0 ? (
-        <Grid mx={'xs'}>
-          {selectedActions.map((selectedAction) => (
-            <KeybindInfo
-              key={selectedAction.identifier}
-              selectedAction={selectedAction}
-            />
-          ))}
-        </Grid>
-      ) : (
-        <Text>
-          {hasSelectedKeys
-            ? 'No action is associated with this keybind.'
-            : 'No key selected. Select a key to see its action.'}
-        </Text>
-      )}
     </Container>
   );
 }

--- a/src/panels/KeybindsPanel/KeyboardLayout.tsx
+++ b/src/panels/KeybindsPanel/KeyboardLayout.tsx
@@ -33,10 +33,7 @@ export function KeyboardLayout() {
           {selectedActions.length > 0 ? (
             <Grid mx={'xs'}>
               {selectedActions.map((selectedAction) => (
-                <KeybindInfo
-                  key={selectedAction.identifier}
-                  selectedAction={selectedAction}
-                />
+                <KeybindInfo key={selectedAction.identifier} action={selectedAction} />
               ))}
             </Grid>
           ) : (

--- a/src/panels/KeybindsPanel/ListEntry.tsx
+++ b/src/panels/KeybindsPanel/ListEntry.tsx
@@ -1,0 +1,28 @@
+import { Button, Text } from '@mantine/core';
+
+import { KeybindInfoType } from '@/types/types';
+
+import { KeybindButtons } from './KeybindButtons';
+
+interface Props {
+  keybind: KeybindInfoType;
+  onClick: () => void;
+  isSelected: boolean;
+}
+
+export function ListEntry({ keybind, onClick, isSelected }: Props) {
+  return (
+    <Button
+      onClick={onClick}
+      size={'md'}
+      variant={isSelected ? 'filled' : 'light'}
+      fullWidth
+      rightSection={
+        <KeybindButtons modifiers={keybind.modifiers} selectedKey={keybind.key} />
+      }
+      justify={'space-between'}
+    >
+      <Text truncate>{keybind.name}</Text>
+    </Button>
+  );
+}

--- a/src/panels/KeybindsPanel/ListLayout.tsx
+++ b/src/panels/KeybindsPanel/ListLayout.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Box, Chip, Group } from '@mantine/core';
+import { Box, Chip, Group, Paper, Text } from '@mantine/core';
 
 import { FilterList } from '@/components/FilterList/FilterList';
 import { useSearchKeySettings } from '@/components/FilterList/SearchSettingsMenu/hook';
@@ -100,7 +100,13 @@ export function ListLayout() {
         </FilterList>
       </Box>
       <Box flex={1}>
-        {selectedAction && <KeybindInfo selectedAction={selectedAction} />}
+        {selectedAction ? (
+          <KeybindInfo selectedAction={selectedAction} />
+        ) : (
+          <Paper p={'md'}>
+            <Text>Select a keybind to see more info</Text>
+          </Paper>
+        )}
       </Box>
     </Group>
   );

--- a/src/panels/KeybindsPanel/ListLayout.tsx
+++ b/src/panels/KeybindsPanel/ListLayout.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
-import { Chip, Container, Group } from '@mantine/core';
+import { Box, Chip, Group } from '@mantine/core';
 
 import { FilterList } from '@/components/FilterList/FilterList';
 import { useSearchKeySettings } from '@/components/FilterList/SearchSettingsMenu/hook';
 import { generateMatcherFunctionByKeys } from '@/components/FilterList/util';
-import { Layout } from '@/components/Layout/Layout';
 import { useAppSelector } from '@/redux/hooks';
 import { Action, KeybindInfoType, KeybindModifiers } from '@/types/types';
 
@@ -53,57 +52,56 @@ export function ListLayout() {
   }
 
   return (
-    <Container>
-      <Layout pb={'xs'}>
-        <Layout.GrowingSection py={'md'}>
-          <FilterList>
-            <Group gap={'xs'}>
-              <FilterList.InputField
-                placeHolderSearchText={'Search for a keybind'}
-                flex={1}
-                miw={200}
-              />
-              <Group gap={5}>
-                <Chip.Group
-                  multiple
-                  onChange={(value) => setModifiersFilter(value as KeybindModifiers)}
-                >
-                  <Chip value={'shift'} size={'xs'}>
-                    Shift
-                  </Chip>
-                  <Chip value={'control'} size={'xs'}>
-                    Ctrl
-                  </Chip>
-                  <Chip value={'alt'} size={'xs'}>
-                    Alt
-                  </Chip>
-                </Chip.Group>
-              </Group>
-              <FilterList.SearchSettingsMenu
-                keys={allowedSearchKeys}
-                setKey={toggleSearchKey}
-              />
+    <Group align={'top'} p={'md'}>
+      <Box flex={2}>
+        <FilterList>
+          <Group gap={'xs'}>
+            <FilterList.InputField
+              placeHolderSearchText={'Search for a keybind'}
+              flex={1}
+              miw={200}
+            />
+            <Group gap={5}>
+              <Chip.Group
+                multiple
+                onChange={(value) => setModifiersFilter(value as KeybindModifiers)}
+              >
+                <Chip value={'shift'} size={'xs'}>
+                  Shift
+                </Chip>
+                <Chip value={'control'} size={'xs'}>
+                  Ctrl
+                </Chip>
+                <Chip value={'alt'} size={'xs'}>
+                  Alt
+                </Chip>
+              </Chip.Group>
             </Group>
-            <FilterList.SearchResults
-              data={keybindInfo}
-              renderElement={(entry) => (
-                <ListEntry
-                  key={entry.identifier}
-                  keybind={entry}
-                  onClick={() => onClick(entry)}
-                  isSelected={entry.identifier === selectedAction?.identifier}
-                />
-              )}
-              matcherFunc={generateMatcherFunctionByKeys(selectedSearchKeys)}
-            >
-              <FilterList.SearchResults.VirtualList gap={'xs'} />
-            </FilterList.SearchResults>
-          </FilterList>
-        </Layout.GrowingSection>
-        <Layout.FixedSection>
-          {selectedAction && <KeybindInfo selectedAction={selectedAction} />}
-        </Layout.FixedSection>
-      </Layout>
-    </Container>
+            <FilterList.SearchSettingsMenu
+              keys={allowedSearchKeys}
+              setKey={toggleSearchKey}
+            />
+          </Group>
+
+          <FilterList.SearchResults
+            data={keybindInfo}
+            renderElement={(entry) => (
+              <ListEntry
+                key={entry.identifier}
+                keybind={entry}
+                onClick={() => onClick(entry)}
+                isSelected={entry.identifier === selectedAction?.identifier}
+              />
+            )}
+            matcherFunc={generateMatcherFunctionByKeys(selectedSearchKeys)}
+          >
+            <FilterList.SearchResults.VirtualList gap={'xs'} />
+          </FilterList.SearchResults>
+        </FilterList>
+      </Box>
+      <Box flex={1}>
+        {selectedAction && <KeybindInfo selectedAction={selectedAction} />}
+      </Box>
+    </Group>
   );
 }

--- a/src/panels/KeybindsPanel/ListLayout.tsx
+++ b/src/panels/KeybindsPanel/ListLayout.tsx
@@ -101,7 +101,7 @@ export function ListLayout() {
       </Box>
       <Box flex={1}>
         {selectedAction ? (
-          <KeybindInfo selectedAction={selectedAction} />
+          <KeybindInfo action={selectedAction} />
         ) : (
           <Paper p={'md'}>
             <Text>Select a keybind to see more info</Text>

--- a/src/panels/KeybindsPanel/ListLayout.tsx
+++ b/src/panels/KeybindsPanel/ListLayout.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button, Chip, Container, Group, Text } from '@mantine/core';
+import { Chip, Container, Group } from '@mantine/core';
 
 import { FilterList } from '@/components/FilterList/FilterList';
 import { useSearchKeySettings } from '@/components/FilterList/SearchSettingsMenu/hook';
@@ -8,8 +8,8 @@ import { Layout } from '@/components/Layout/Layout';
 import { useAppSelector } from '@/redux/hooks';
 import { Action, KeybindInfoType, KeybindModifiers } from '@/types/types';
 
-import { KeybindButtons } from './KeybindButtons';
 import { KeybindInfo } from './KeybindInfo';
+import { ListEntry } from './ListEntry';
 
 export function ListLayout() {
   const [selectedAction, setSelectedAction] = useState<Action | null>(null);
@@ -86,21 +86,13 @@ export function ListLayout() {
             </Group>
             <FilterList.SearchResults
               data={keybindInfo}
-              renderElement={(node) => (
-                <Button
-                  onClick={() => onClick(node)}
-                  size={'md'}
-                  variant={
-                    node.identifier === selectedAction?.identifier ? 'filled' : 'light'
-                  }
-                  fullWidth
-                  rightSection={
-                    <KeybindButtons modifiers={node.modifiers} selectedKey={node.key} />
-                  }
-                  justify={'space-between'}
-                >
-                  <Text truncate>{node.name}</Text>
-                </Button>
+              renderElement={(entry) => (
+                <ListEntry
+                  key={entry.identifier}
+                  keybind={entry}
+                  onClick={() => onClick(entry)}
+                  isSelected={entry.identifier === selectedAction?.identifier}
+                />
               )}
               matcherFunc={generateMatcherFunctionByKeys(selectedSearchKeys)}
             >

--- a/src/panels/KeybindsPanel/ListLayout.tsx
+++ b/src/panels/KeybindsPanel/ListLayout.tsx
@@ -4,13 +4,19 @@ import { Box, Chip, Group, Paper, Text } from '@mantine/core';
 import { FilterList } from '@/components/FilterList/FilterList';
 import { useSearchKeySettings } from '@/components/FilterList/SearchSettingsMenu/hook';
 import { generateMatcherFunctionByKeys } from '@/components/FilterList/util';
+import { Layout } from '@/components/Layout/Layout';
 import { useAppSelector } from '@/redux/hooks';
 import { Action, KeybindInfoType, KeybindModifiers } from '@/types/types';
 
 import { KeybindInfo } from './KeybindInfo';
 import { ListEntry } from './ListEntry';
 
-export function ListLayout() {
+interface Props {
+  // The height of this view, used to get the scrolling behavior right
+  height: number;
+}
+
+export function ListLayout({ height }: Props) {
   const [selectedAction, setSelectedAction] = useState<Action | null>(null);
   const [modifiersFilter, setModifiersFilter] = useState<KeybindModifiers>([]);
   const keybinds = useAppSelector((state) => state.actions.keybinds);
@@ -52,54 +58,60 @@ export function ListLayout() {
   }
 
   return (
-    <Group align={'top'} p={'md'}>
-      <Box flex={2}>
-        <FilterList>
-          <Group gap={'xs'}>
-            <FilterList.InputField
-              placeHolderSearchText={'Search for a keybind'}
-              flex={1}
-              miw={200}
-            />
-            <Group gap={5}>
-              <Chip.Group
-                multiple
-                onChange={(value) => setModifiersFilter(value as KeybindModifiers)}
-              >
-                <Chip value={'shift'} size={'xs'}>
-                  Shift
-                </Chip>
-                <Chip value={'control'} size={'xs'}>
-                  Ctrl
-                </Chip>
-                <Chip value={'alt'} size={'xs'}>
-                  Alt
-                </Chip>
-              </Chip.Group>
-            </Group>
-            <FilterList.SearchSettingsMenu
-              keys={allowedSearchKeys}
-              setKey={toggleSearchKey}
-            />
-          </Group>
+    <Group align={'top'} px={'xs'}>
+      <Box h={height} pt={'xs'} flex={2}>
+        <Layout>
+          <FilterList>
+            <Layout.FixedSection>
+              <Group gap={'xs'}>
+                <FilterList.InputField
+                  placeHolderSearchText={'Search for a keybind'}
+                  flex={1}
+                  miw={200}
+                />
+                <Group gap={5}>
+                  <Chip.Group
+                    multiple
+                    onChange={(value) => setModifiersFilter(value as KeybindModifiers)}
+                  >
+                    <Chip value={'shift'} size={'xs'}>
+                      Shift
+                    </Chip>
+                    <Chip value={'control'} size={'xs'}>
+                      Ctrl
+                    </Chip>
+                    <Chip value={'alt'} size={'xs'}>
+                      Alt
+                    </Chip>
+                  </Chip.Group>
+                </Group>
+                <FilterList.SearchSettingsMenu
+                  keys={allowedSearchKeys}
+                  setKey={toggleSearchKey}
+                />
+              </Group>
+            </Layout.FixedSection>
 
-          <FilterList.SearchResults
-            data={keybindInfo}
-            renderElement={(entry) => (
-              <ListEntry
-                key={entry.identifier}
-                keybind={entry}
-                onClick={() => onClick(entry)}
-                isSelected={entry.identifier === selectedAction?.identifier}
-              />
-            )}
-            matcherFunc={generateMatcherFunctionByKeys(selectedSearchKeys)}
-          >
-            <FilterList.SearchResults.VirtualList gap={'xs'} />
-          </FilterList.SearchResults>
-        </FilterList>
+            <Layout.GrowingSection>
+              <FilterList.SearchResults
+                data={keybindInfo}
+                renderElement={(entry) => (
+                  <ListEntry
+                    key={entry.identifier}
+                    keybind={entry}
+                    onClick={() => onClick(entry)}
+                    isSelected={entry.identifier === selectedAction?.identifier}
+                  />
+                )}
+                matcherFunc={generateMatcherFunctionByKeys(selectedSearchKeys)}
+              >
+                <FilterList.SearchResults.VirtualList gap={'xs'} />
+              </FilterList.SearchResults>
+            </Layout.GrowingSection>
+          </FilterList>
+        </Layout>
       </Box>
-      <Box flex={1}>
+      <Box flex={1} pt={'xs'}>
         {selectedAction ? (
           <KeybindInfo action={selectedAction} />
         ) : (

--- a/src/panels/KeybindsPanel/ListLayout.tsx
+++ b/src/panels/KeybindsPanel/ListLayout.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button, Chip, Group, Text } from '@mantine/core';
+import { Button, Chip, Container, Group, Text } from '@mantine/core';
 
 import { FilterList } from '@/components/FilterList/FilterList';
 import { useSearchKeySettings } from '@/components/FilterList/SearchSettingsMenu/hook';
@@ -53,63 +53,65 @@ export function ListLayout() {
   }
 
   return (
-    <Layout pb={'xs'}>
-      <Layout.GrowingSection py={'md'}>
-        <FilterList>
-          <Group gap={'xs'}>
-            <FilterList.InputField
-              placeHolderSearchText={'Search for a keybind'}
-              flex={1}
-              miw={200}
-            />
-            <Group gap={5}>
-              <Chip.Group
-                multiple
-                onChange={(value) => setModifiersFilter(value as KeybindModifiers)}
-              >
-                <Chip value={'shift'} size={'xs'}>
-                  Shift
-                </Chip>
-                <Chip value={'control'} size={'xs'}>
-                  Ctrl
-                </Chip>
-                <Chip value={'alt'} size={'xs'}>
-                  Alt
-                </Chip>
-              </Chip.Group>
+    <Container>
+      <Layout pb={'xs'}>
+        <Layout.GrowingSection py={'md'}>
+          <FilterList>
+            <Group gap={'xs'}>
+              <FilterList.InputField
+                placeHolderSearchText={'Search for a keybind'}
+                flex={1}
+                miw={200}
+              />
+              <Group gap={5}>
+                <Chip.Group
+                  multiple
+                  onChange={(value) => setModifiersFilter(value as KeybindModifiers)}
+                >
+                  <Chip value={'shift'} size={'xs'}>
+                    Shift
+                  </Chip>
+                  <Chip value={'control'} size={'xs'}>
+                    Ctrl
+                  </Chip>
+                  <Chip value={'alt'} size={'xs'}>
+                    Alt
+                  </Chip>
+                </Chip.Group>
+              </Group>
+              <FilterList.SearchSettingsMenu
+                keys={allowedSearchKeys}
+                setKey={toggleSearchKey}
+              />
             </Group>
-            <FilterList.SearchSettingsMenu
-              keys={allowedSearchKeys}
-              setKey={toggleSearchKey}
-            />
-          </Group>
-          <FilterList.SearchResults
-            data={keybindInfo}
-            renderElement={(node) => (
-              <Button
-                onClick={() => onClick(node)}
-                size={'md'}
-                variant={
-                  node.identifier === selectedAction?.identifier ? 'filled' : 'light'
-                }
-                fullWidth
-                rightSection={
-                  <KeybindButtons modifiers={node.modifiers} selectedKey={node.key} />
-                }
-                justify={'space-between'}
-              >
-                <Text truncate>{node.name}</Text>
-              </Button>
-            )}
-            matcherFunc={generateMatcherFunctionByKeys(selectedSearchKeys)}
-          >
-            <FilterList.SearchResults.VirtualList gap={'xs'} />
-          </FilterList.SearchResults>
-        </FilterList>
-      </Layout.GrowingSection>
-      <Layout.FixedSection>
-        {selectedAction && <KeybindInfo selectedAction={selectedAction} />}
-      </Layout.FixedSection>
-    </Layout>
+            <FilterList.SearchResults
+              data={keybindInfo}
+              renderElement={(node) => (
+                <Button
+                  onClick={() => onClick(node)}
+                  size={'md'}
+                  variant={
+                    node.identifier === selectedAction?.identifier ? 'filled' : 'light'
+                  }
+                  fullWidth
+                  rightSection={
+                    <KeybindButtons modifiers={node.modifiers} selectedKey={node.key} />
+                  }
+                  justify={'space-between'}
+                >
+                  <Text truncate>{node.name}</Text>
+                </Button>
+              )}
+              matcherFunc={generateMatcherFunctionByKeys(selectedSearchKeys)}
+            >
+              <FilterList.SearchResults.VirtualList gap={'xs'} />
+            </FilterList.SearchResults>
+          </FilterList>
+        </Layout.GrowingSection>
+        <Layout.FixedSection>
+          {selectedAction && <KeybindInfo selectedAction={selectedAction} />}
+        </Layout.FixedSection>
+      </Layout>
+    </Container>
   );
 }

--- a/src/windowmanagement/data/MenuItems.tsx
+++ b/src/windowmanagement/data/MenuItems.tsx
@@ -185,7 +185,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     defaultVisible: !window.isWithinCEF
   },
   keybindingsLayout: {
-    title: 'Keybindings Layout',
+    title: 'Keybinds',
     componentID: 'keybindingsLayout',
     content: <KeybindsPanel />,
     renderIcon: (size) => <KeyboardIcon size={size} />,

--- a/src/windowmanagement/data/MenuItems.tsx
+++ b/src/windowmanagement/data/MenuItems.tsx
@@ -190,7 +190,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     content: <KeybindsPanel />,
     renderIcon: (size) => <KeyboardIcon size={size} />,
     preferredPosition: 'float',
-    floatPosition: { offsetY: 150, offsetX: 350, width: 1050, height: 680 },
+    floatPosition: { offsetY: 150, offsetX: 350, width: 1100, height: 680 },
     defaultVisible: false
   },
   gettingStartedTour: {


### PR DESCRIPTION
1. Changes title to "Keybinds" instead of "Keybindings Layout", since it now also includes a list of all keybinds
2. Add the identifier of the bound action, and a copy button 
3. Change tab style to be consistent with tabs in other places
4. Increase width to fit entire keyboard
5. General tighten up, and redesign both layouts to work better with the wide format that the panel has, due to the keyboard

After: 
<img src="https://github.com/user-attachments/assets/a071fced-01bc-409f-8653-c84182884f0c" width="45%"><img src="https://github.com/user-attachments/assets/8038ed31-ec42-48d0-9129-fb7b1d54fe0b" width="45%">


Before:
<img src="https://github.com/user-attachments/assets/16b24ffe-c8b4-4e71-86c1-efebc6895d87" width="45%"><img src="https://github.com/user-attachments/assets/4ef44d99-dc22-4f1f-b257-d5fab7381d07" width="45%">


Ley me know what you think about the redesign, especially the list view. If we don't like the change of moving the selected keybind to the right instead of the bottom, I can change it back to how it was before
