### PR TITLE
fix for night sky direciton buttons

### DIFF
--- a/src/panels/NightSkyPanel/tabs/LocationTab.tsx
+++ b/src/panels/NightSkyPanel/tabs/LocationTab.tsx
@@ -47,7 +47,7 @@ export function LocationTab() {
   }
 
   function look(direction: LookDirection): void {
-    luaApi?.action.triggerAction(`os.nightsky.Looking'${direction}`);
+    luaApi?.action.triggerAction(`os.nightsky.Looking${direction}`);
   }
 
   if (!luaApi) {


### PR DESCRIPTION
Closes: https://github.com/OpenSpace/OpenSpace/issues/3671

There was an issue with the string escaping that created this error message: `(E) Lua                  Error executing script '': [string "return openspace.action.triggerAction("os.nig..."]:1: Action 'os.nightsky.Looking'West' not found
`

Now the extra ' is removed
