### PR TITLE
accounting for pin size in position on night sky map, also overflow

### DIFF
--- a/src/panels/NightSkyPanel/tabs/LocationTab.tsx
+++ b/src/panels/NightSkyPanel/tabs/LocationTab.tsx
@@ -39,7 +39,7 @@ export function LocationTab() {
 
   const iconSize = 10;
   const mapSize = {w: 300, h: 150}
-  const iconOffset = {x: (iconSize+4)/2/mapSize.w, y: iconSize/2/mapSize.h};
+  const iconOffset = {x: (iconSize + 4) / (2 * mapSize.w), y: iconSize / (2 * mapSize.h)};
 
   function dotPosition(): { x: number; y: number } {
     if (currentLong !== undefined && currentLat !== undefined) {

--- a/src/panels/NightSkyPanel/tabs/LocationTab.tsx
+++ b/src/panels/NightSkyPanel/tabs/LocationTab.tsx
@@ -37,11 +37,18 @@ export function LocationTab() {
 
   const anchor = useAnchorNode();
 
+  const iconSize = 10;
+  const mapSize = {w: 300, h: 150}
+  const iconOffset = {x: (iconSize+4)/2/mapSize.w, y: iconSize/2/mapSize.h};
+
   function dotPosition(): { x: number; y: number } {
     if (currentLong !== undefined && currentLat !== undefined) {
       // Here we are getting the percentage of the map on where to show the marker
       // for example, lat, long of 0,0 winds up with a map position of x: 0.5 and y: 0.5
-      return { x: ((currentLong + 180) / 360) * 100, y: ((90 - currentLat) / 180) * 100 };
+      return {
+        x: ( ( (currentLong + 180) / 360) - iconOffset.x) * 100,
+        y: ( ( (90 - currentLat) / 180) - iconOffset.y) * 100
+      }
     }
     return { x: 0, y: 0 };
   }
@@ -66,14 +73,14 @@ export function LocationTab() {
           <Text size={'md'}>Altitude: {currentAlt?.toFixed(2)}m</Text>
         </Stack>
 
-        <BackgroundImage w={300} h={150} src={'eqcy.png'} radius={'sm'}>
+        <BackgroundImage w={mapSize.w} h={mapSize.h} src={'eqcy.png'} radius={'sm'} styles={{root:{overflow:'hidden'}}}>
           <Image
             src={'icon.png'}
             style={{
-              width: '10px',
+              width: iconSize + 'px',
               position: 'relative',
-              left: dotPosition().x - 0.1666666 + '%', //here i was just trying to account for the marker
-              top: dotPosition().y - 0.1666666 + '%' //it should be centered instead of top left corner
+              left: dotPosition().x + '%',
+              top: dotPosition().y + '%'
             }}
           />
         </BackgroundImage>

--- a/src/panels/NightSkyPanel/tabs/LocationTab.tsx
+++ b/src/panels/NightSkyPanel/tabs/LocationTab.tsx
@@ -38,17 +38,20 @@ export function LocationTab() {
   const anchor = useAnchorNode();
 
   const iconSize = 10;
-  const mapSize = {w: 300, h: 150}
-  const iconOffset = {x: (iconSize + 4) / (2 * mapSize.w), y: iconSize / (2 * mapSize.h)};
+  const mapSize = { w: 300, h: 150 };
+  const iconOffset = {
+    x: (iconSize + 4) / (2 * mapSize.w),
+    y: iconSize / (2 * mapSize.h)
+  };
 
   function dotPosition(): { x: number; y: number } {
     if (currentLong !== undefined && currentLat !== undefined) {
       // Here we are getting the percentage of the map on where to show the marker
       // for example, lat, long of 0,0 winds up with a map position of x: 0.5 and y: 0.5
       return {
-        x: ( ( (currentLong + 180) / 360) - iconOffset.x) * 100,
-        y: ( ( (90 - currentLat) / 180) - iconOffset.y) * 100
-      }
+        x: ((currentLong + 180) / 360 - iconOffset.x) * 100,
+        y: ((90 - currentLat) / 180 - iconOffset.y) * 100
+      };
     }
     return { x: 0, y: 0 };
   }
@@ -73,7 +76,13 @@ export function LocationTab() {
           <Text size={'md'}>Altitude: {currentAlt?.toFixed(2)}m</Text>
         </Stack>
 
-        <BackgroundImage w={mapSize.w} h={mapSize.h} src={'eqcy.png'} radius={'sm'} styles={{root:{overflow:'hidden'}}}>
+        <BackgroundImage
+          w={mapSize.w}
+          h={mapSize.h}
+          src={'eqcy.png'}
+          radius={'sm'}
+          styles={{ root: { overflow: 'hidden' } }}
+        >
           <Image
             src={'icon.png'}
             style={{


### PR DESCRIPTION
Closes https://github.com/OpenSpace/OpenSpace/issues/3673

Added the size of the image into the calculation for the marker position.

Added overflow hidden to parent container for when the marker is on the edge.

New: (0,0) and (0,180)
![image](https://github.com/user-attachments/assets/dd3d8439-78fb-44bf-badb-5321fd5d7e05)
![image](https://github.com/user-attachments/assets/9c0c0a87-2c67-4138-a2a4-bc8b102bfc9f)

Old (0,0) and (0,180)
![image](https://github.com/user-attachments/assets/0c7c7f16-7257-4b18-a000-59a3c7c9dbf5)
![image](https://github.com/user-attachments/assets/0dc7cb90-6366-41d4-a155-e8fd1f81efe9)


