### PR TITLE
Change basename of repo to "gui" and update the routes accordingly

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "homepage": "/gui",
   "scripts": {
     "dev": "vite",
     "prebuild": "npm install",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,11 +31,13 @@ function App() {
             defaultColorScheme={'dark'}
             cssVariablesResolver={cssVariablesResolver}
           >
-            <BrowserRouter>
+            <BrowserRouter basename="/gui">
               <Routes>
-                <Route index element={<RoutesPage />} />
-                <Route path={'/frontend'} element={<GuiPage />} />
-                <Route path={'/actions'} element={<ActionsPage />} />
+                <Route index element={<GuiPage />} />
+                <Route path={'routes'} element={<RoutesPage />} />
+                <Route path={'actions'} element={<ActionsPage />} />
+                {/* Fallback route for any undefined paths */}
+                <Route path="*" element={<GuiPage />} />
               </Routes>
             </BrowserRouter>
           </MantineProvider>

--- a/src/localization/config.tsx
+++ b/src/localization/config.tsx
@@ -12,8 +12,6 @@ export const SupportedLanguages: Record<string, LanguageInfo> = {
   sv: { language: 'Swedish', icon: <SE width={20} /> }
 };
 
-// @TODO anden88 2025-05-19: Temporary fix to get translation lookup working correctly
-const basePath = import.meta.env.PROD ? '/frontend/' : '/';
 i18n
   .use(HttpApi)
   .use(initReactI18next)
@@ -31,7 +29,7 @@ i18n
       escapeValue: false
     },
     backend: {
-      loadPath: `${basePath}locales/{{lng}}/{{ns}}.json`
+      loadPath: `locales/{{lng}}/{{ns}}.json`
     }
   });
 

--- a/src/pages/RoutesPage.tsx
+++ b/src/pages/RoutesPage.tsx
@@ -27,13 +27,13 @@ export function RoutesPage() {
 
       <AppShell.Navbar p={'md'}>
         <NavLink
-          href={'/frontend'}
+          href={'/gui'}
           label={'GUI'}
           leftSection={<HomeIcon />}
           description={'The regular OpenSpace GUI'}
         />
         <NavLink
-          href={'/actions'}
+          href={'/gui/actions'}
           label={'Actions'}
           description={'Actions panel opened up as a page'}
           leftSection={<DashboardIcon />}

--- a/src/util/networkingHooks.ts
+++ b/src/util/networkingHooks.ts
@@ -14,7 +14,7 @@ export function useWebGuiUrl(): string {
   useEffect(() => {
     const port = portProperty ?? 4680;
     const address = addressProperty ?? 'localhost';
-    setLink(`http://${address}:${port}`);
+    setLink(`http://${address}:${port}/gui`);
   }, [portProperty, addressProperty]);
 
   return link;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     host: true, // Allows access from both localhost and 127.0.0.1
     port: 4690
   },
-  base: './',
+  base: '/gui',
   build: {
     rollupOptions: {
       output: {


### PR DESCRIPTION
To be used with [this PR](https://github.com/OpenSpace/OpenSpace-WebGuiBackend/pull/23) and this.

 * Changes the base name of the repo to be `gui` as that is how it is set in the asset
 * Redirects all undefined routes to `gui`
 * `gui` is now where the gui is served
 * Changed the routes a bit