### PR TITLE
Use the setFocus function in the NodeNavigationButton as well

### DIFF
--- a/src/components/NodeNavigationButton/NodeNavigationButton.tsx
+++ b/src/components/NodeNavigationButton/NodeNavigationButton.tsx
@@ -18,7 +18,6 @@ import {
 } from '@/icons/icons';
 import { NavigationType } from '@/types/enums';
 import { Identifier } from '@/types/types';
-import { NavigationAimKey, NavigationAnchorKey, RetargetAnchorKey } from '@/util/keys';
 
 interface BaseProps {
   type: NavigationType;


### PR DESCRIPTION
Untested right now due to main.tsx build errors on my system.

This replaces the old-style three-function call for setting the focus with the new `setFocus` function.  This also adds the CTRL button to keep the old velocities to make the different buttons behave the same way