### PR TITLE
Fix routing so that actions is nested under `/gui`

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,13 +31,12 @@ function App() {
             defaultColorScheme={'dark'}
             cssVariablesResolver={cssVariablesResolver}
           >
-            <BrowserRouter
-              basename={import.meta.env.MODE === 'production' ? '/gui' : '/'}
-            >
+            <BrowserRouter>
               <Routes>
-                <Route index element={<GuiPage />} />
                 <Route path={'routes'} element={<RoutesPage />} />
-                <Route path={'actions'} element={<ActionsPage />} />
+                <Route path={'/gui'} element={<GuiPage />}>
+                  <Route path={'actions'} element={<ActionsPage />} />
+                </Route>
                 {/* Fallback route for any undefined paths */}
                 <Route path={'*'} element={<GuiPage />} />
               </Routes>


### PR DESCRIPTION
The link in the routing page was correct but the webpage was not hosting the action page under the correct link.  

This seems to fix it, and the routes structure now matches how the UI pages are structured, I think .Would be good with a second opinion. 

@ylvaselling 