### PR TITLE
Add tab to add browser/webpage in screenspace renderables panel

### DIFF
--- a/public/locales/en/panel-screenspacerenderable.json
+++ b/public/locales/en/panel-screenspacerenderable.json
@@ -3,10 +3,17 @@
     "title": "Display name",
     "placeholder": "Slide name"
   },
-  "slide-path-input": {
-    "title": "Path or URL to slide",
+  "image-input": {
+    "tab-title": "Image",
+    "title": "Path or URL to image",
     "placeholder": "Path / URL",
-    "button-label": "Add slide"
+    "button-label": "Add"
+  },
+  "website-input": {
+    "tab-title": "Website",
+    "title": "URL to website",
+    "placeholder": "URL",
+    "button-label": "Add"
   },
   "added-slides": {
     "empty-slides": "No active slides",

--- a/src/icons/icons.tsx
+++ b/src/icons/icons.tsx
@@ -108,12 +108,14 @@ export {
 export { RiFocus3Line as FocusIcon, RiRouteLine as RouteIcon } from 'react-icons/ri';
 export {
   TbAbc as AbcIcon,
+  TbBrowserPlus as AddBrowserIcon,
   TbClock as ClockIcon,
   TbClockX as ClockOffIcon,
   TbCompass as CompassMarksIcon,
   TbSphere as LineIcon,
   TbCube as SceneIcon,
-  TbScript as ScriptLogIcon
+  TbScript as ScriptLogIcon,
+  TbWorldWww as WebIcon
 } from 'react-icons/tb';
 export {
   VscFeedback as FeedbackIcon,

--- a/src/panels/KeybindsPanel/KeybindsPanel.tsx
+++ b/src/panels/KeybindsPanel/KeybindsPanel.tsx
@@ -14,7 +14,7 @@ export function KeybindsPanel() {
   const { ref, height: tabsHeight } = useElementSize();
 
   return (
-    <Tabs radius={'md'} defaultValue={'keyboardLayout'}>
+    <Tabs defaultValue={'keyboardLayout'}>
       <Tabs.List ref={ref}>
         <Tabs.Tab value={'keyboardLayout'}>{t('keyboard-view-tab-title')}</Tabs.Tab>
         <Tabs.Tab value={'listLayout'}>{t('list-view-tab-title')}</Tabs.Tab>

--- a/src/panels/ScreenSpaceRenderablePanel/ImageTab.tsx
+++ b/src/panels/ScreenSpaceRenderablePanel/ImageTab.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button, Group, TextInput } from '@mantine/core';
+
+import { useOpenSpaceApi } from '@/api/hooks';
+import { AddPhotoIcon } from '@/icons/icons';
+import { useAppDispatch } from '@/redux/hooks';
+import { handleNotificationLogging } from '@/redux/logging/loggingMiddleware';
+import { IconSize, LogLevel } from '@/types/enums';
+import { Identifier } from '@/types/types';
+
+interface ScreenSpaceRenderable {
+  Identifier: Identifier;
+  Name: string;
+  Type: 'ScreenSpaceImageLocal' | 'ScreenSpaceImageOnline';
+  TexturePath?: string;
+  URL?: string;
+}
+
+export function ImageTab() {
+  const [slideName, setSlideName] = useState('');
+  const [slideURL, setSlideURL] = useState('');
+  const luaApi = useOpenSpaceApi();
+  const { t } = useTranslation('panel-screenspacerenderable');
+  const dispatch = useAppDispatch();
+
+  const isButtonDisabled = !slideName || !slideURL;
+
+  async function addSlide() {
+    const osIdentifier = (await luaApi?.makeIdentifier(slideName)) ?? slideName;
+
+    const renderable: ScreenSpaceRenderable = {
+      Identifier: osIdentifier,
+      Name: slideName,
+      Type: 'ScreenSpaceImageLocal'
+    };
+
+    let urlOrPath = slideURL;
+    if (slideURL.startsWith('data:image/')) {
+      let url = slideURL;
+      // Someone tried to paste a base64 encoded image. It starts with the text:
+      // data:image/{png/jpeg};base,
+      // followed by the rest of the image data in base64 encoding
+      url = url.substring('data:image/'.length);
+
+      const filetype = url.substring(0, url.indexOf(';'));
+      if (filetype !== 'png' && filetype !== 'jpeg') {
+        dispatch(
+          handleNotificationLogging(
+            t('error.title'),
+            t('error.description', { format: filetype }),
+            LogLevel.Error
+          )
+        );
+        return;
+      }
+
+      // Remove the remaining header information, at which point it becomes the data
+      const data = url.substring(url.indexOf(',') + 1);
+
+      // eslint-disable-next-line no-template-curly-in-string
+      const tempPath = await luaApi?.absPath('${TEMPORARY}');
+      const localPath = `${tempPath}/screenspace-slide-${slideName}.${filetype}`;
+      await luaApi?.saveBase64File(localPath, data);
+      urlOrPath = localPath;
+    }
+
+    const isHttpSlide = urlOrPath.indexOf('http') === 0;
+    if (isHttpSlide) {
+      renderable.Type = 'ScreenSpaceImageOnline';
+      renderable.URL = urlOrPath;
+    } else {
+      renderable.Type = 'ScreenSpaceImageLocal';
+      renderable.TexturePath = urlOrPath;
+    }
+
+    luaApi?.addScreenSpaceRenderable(renderable);
+    setSlideName('');
+    setSlideURL('');
+  }
+
+  return (
+    <Group gap={'xs'} grow preventGrowOverflow={false} align={'end'}>
+      <TextInput
+        value={slideName}
+        onChange={(event) => setSlideName(event.currentTarget.value)}
+        placeholder={t('display-name-input.placeholder')}
+        label={t('display-name-input.title')}
+      />
+      <TextInput
+        value={slideURL}
+        onChange={(event) => setSlideURL(event.currentTarget.value)}
+        placeholder={t('image-input.placeholder')}
+        label={t('image-input.title')}
+      />
+      <Button
+        onClick={addSlide}
+        leftSection={<AddPhotoIcon size={IconSize.sm} />}
+        disabled={isButtonDisabled}
+      >
+        {t('image-input.button-label')}
+      </Button>
+    </Group>
+  );
+}

--- a/src/panels/ScreenSpaceRenderablePanel/ScreenSpaceRenderablePanel.tsx
+++ b/src/panels/ScreenSpaceRenderablePanel/ScreenSpaceRenderablePanel.tsx
@@ -1,88 +1,23 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ActionIcon, Box, Button, Divider, Group, Text, TextInput } from '@mantine/core';
+import { ActionIcon, Box, Divider, Group, Tabs, Text } from '@mantine/core';
 
 import { useOpenSpaceApi } from '@/api/hooks';
 import { PropertyOwner } from '@/components/PropertyOwner/PropertyOwner';
 import { usePropertyOwner } from '@/hooks/propertyOwner';
-import { AddPhotoIcon, MinusIcon } from '@/icons/icons';
-import { useAppDispatch } from '@/redux/hooks';
-import { handleNotificationLogging } from '@/redux/logging/loggingMiddleware';
-import { IconSize, LogLevel } from '@/types/enums';
-import { Identifier, Uri } from '@/types/types';
+import { InsertPhotoIcon, MinusIcon, WebIcon } from '@/icons/icons';
+import { IconSize } from '@/types/enums';
+import { Uri } from '@/types/types';
 import { ScreenSpaceKey } from '@/util/keys';
 
-interface ScreenSpaceRenderable {
-  Identifier: Identifier;
-  Name: string;
-  Type: 'ScreenSpaceImageLocal' | 'ScreenSpaceImageOnline';
-  TexturePath?: string;
-  URL?: string;
-}
+import { ImageTab } from './ImageTab';
+import { WebpageTab } from './WebpageTab';
 
 export function ScreenSpaceRenderablePanel() {
-  const [slideName, setSlideName] = useState('');
-  const [slideURL, setSlideURL] = useState('');
   const luaApi = useOpenSpaceApi();
   const screenSpacePropertyOwner = usePropertyOwner(ScreenSpaceKey);
   const { t } = useTranslation('panel-screenspacerenderable');
-  const dispatch = useAppDispatch();
 
   const renderables = screenSpacePropertyOwner?.subowners ?? [];
-  const isButtonDisabled = !slideName || !slideURL;
-
-  async function addSlide() {
-    const osIdentifier = (await luaApi?.makeIdentifier(slideName)) ?? slideName;
-
-    const renderable: ScreenSpaceRenderable = {
-      Identifier: osIdentifier,
-      Name: slideName,
-      Type: 'ScreenSpaceImageLocal'
-    };
-
-    let urlOrPath = slideURL;
-    if (slideURL.startsWith('data:image/')) {
-      let url = slideURL;
-      // Someone tried to paste a base64 encoded image. It starts with the text:
-      // data:image/{png/jpeg};base,
-      // followed by the rest of the image data in base64 encoding
-      url = url.substring('data:image/'.length);
-
-      const filetype = url.substring(0, url.indexOf(';'));
-      if (filetype !== 'png' && filetype !== 'jpeg') {
-        dispatch(
-          handleNotificationLogging(
-            t('error.title'),
-            t('error.description', { format: filetype }),
-            LogLevel.Error
-          )
-        );
-        return;
-      }
-
-      // Remove the remaining header information, at which point it becomes the data
-      const data = url.substring(url.indexOf(',') + 1);
-
-      // eslint-disable-next-line no-template-curly-in-string
-      const tempPath = await luaApi?.absPath('${TEMPORARY}');
-      const localPath = `${tempPath}/screenspace-slide-${slideName}.${filetype}`;
-      await luaApi?.saveBase64File(localPath, data);
-      urlOrPath = localPath;
-    }
-
-    const isHttpSlide = urlOrPath.indexOf('http') === 0;
-    if (isHttpSlide) {
-      renderable.Type = 'ScreenSpaceImageOnline';
-      renderable.URL = urlOrPath;
-    } else {
-      renderable.Type = 'ScreenSpaceImageLocal';
-      renderable.TexturePath = urlOrPath;
-    }
-
-    luaApi?.addScreenSpaceRenderable(renderable);
-    setSlideName('');
-    setSlideURL('');
-  }
 
   function removeSlide(uri: Uri) {
     const identifier = uri.split('.').pop();
@@ -96,27 +31,26 @@ export function ScreenSpaceRenderablePanel() {
 
   return (
     <>
-      <Group gap={'xs'} grow preventGrowOverflow={false} align={'end'}>
-        <TextInput
-          value={slideName}
-          onChange={(event) => setSlideName(event.currentTarget.value)}
-          placeholder={t('display-name-input.placeholder')}
-          label={t('display-name-input.title')}
-        />
-        <TextInput
-          value={slideURL}
-          onChange={(event) => setSlideURL(event.currentTarget.value)}
-          placeholder={t('slide-path-input.placeholder')}
-          label={t('slide-path-input.title')}
-        />
-        <Button
-          onClick={addSlide}
-          leftSection={<AddPhotoIcon size={IconSize.sm} />}
-          disabled={isButtonDisabled}
-        >
-          {t('slide-path-input.button-label')}
-        </Button>
-      </Group>
+      <Tabs defaultValue={'images'}>
+        <Tabs.List>
+          <Tabs.Tab value={'images'} leftSection={<InsertPhotoIcon size={IconSize.sm} />}>
+            {t('image-input.tab-title')}
+          </Tabs.Tab>
+          <Tabs.Tab value={'web'} leftSection={<WebIcon size={IconSize.sm} />}>
+            {t('website-input.tab-title')}
+          </Tabs.Tab>
+        </Tabs.List>
+
+        <Box pt={'xs'}>
+          <Tabs.Panel value={'images'}>
+            <ImageTab />
+          </Tabs.Panel>
+
+          <Tabs.Panel value={'web'}>
+            <WebpageTab />
+          </Tabs.Panel>
+        </Box>
+      </Tabs>
       <Divider my={'xs'} />
       {renderables.length === 0 ? (
         <Text>{t('added-slides.empty-slides')}</Text>

--- a/src/panels/ScreenSpaceRenderablePanel/WebpageTab.tsx
+++ b/src/panels/ScreenSpaceRenderablePanel/WebpageTab.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button, Group, TextInput } from '@mantine/core';
+
+import { useOpenSpaceApi } from '@/api/hooks';
+import { AddBrowserIcon } from '@/icons/icons';
+import { IconSize } from '@/types/enums';
+import { Identifier } from '@/types/types';
+
+interface ScreenSpaceBrowser {
+  Identifier: Identifier;
+  Name: string;
+  Type: 'ScreenSpaceBrowser';
+  Url: string;
+}
+
+export function WebpageTab() {
+  const [slideName, setSlideName] = useState('');
+  const [slideURL, setSlideURL] = useState('');
+  const luaApi = useOpenSpaceApi();
+  const { t } = useTranslation('panel-screenspacerenderable');
+
+  const isAddButtonDisabled = !slideName || !slideURL;
+
+  async function addSlide() {
+    const osIdentifier = (await luaApi?.makeIdentifier(slideName)) ?? slideName;
+
+    const renderable: ScreenSpaceBrowser = {
+      Identifier: osIdentifier,
+      Name: slideName,
+      Type: 'ScreenSpaceBrowser',
+      Url: slideURL
+    };
+
+    luaApi?.addScreenSpaceRenderable(renderable);
+    setSlideName('');
+    setSlideURL('');
+  }
+
+  return (
+    <Group gap={'xs'} grow preventGrowOverflow={false} align={'end'}>
+      <TextInput
+        value={slideName}
+        onChange={(event) => setSlideName(event.currentTarget.value)}
+        placeholder={t('display-name-input.placeholder')}
+        label={t('display-name-input.title')}
+      />
+      <TextInput
+        value={slideURL}
+        onChange={(event) => setSlideURL(event.currentTarget.value)}
+        placeholder={t('website-input.placeholder')}
+        label={t('website-input.title')}
+      />
+      <Button
+        onClick={addSlide}
+        leftSection={<AddBrowserIcon size={IconSize.sm} />}
+        disabled={isAddButtonDisabled}
+      >
+        {t('website-input.button-label')}
+      </Button>
+    </Group>
+  );
+}


### PR DESCRIPTION
Closes OpenSpace/OpenSpace#3387

Image tab (same as before, but titles made clearer that it is an image)
![image](https://github.com/user-attachments/assets/0bc7a1ce-0fe0-4e0f-be66-6241b2a69de1)

Website tab
![image](https://github.com/user-attachments/assets/9e6f2098-6a58-442d-a8d2-0cffa8741f78)
