### PR TITLE
Reset tour related properties & settings before starting it

### DIFF
--- a/public/locales/en/panel-gettingstartedtour.json
+++ b/public/locales/en/panel-gettingstartedtour.json
@@ -65,6 +65,7 @@
         "task-label-complete": "This is a completed task!"
       },
       "lets-go": "Let's dive right in!",
+      "setup-tour": "Go to Start of Tour",
       "other-profile-warning": {
         "title": "Warning",
         "description": "You are not using the Default profile. Some tour steps may not work as expected. If you encounter issues, please restart OpenSpace using the Default profile."

--- a/public/locales/en/panel-gettingstartedtour.json
+++ b/public/locales/en/panel-gettingstartedtour.json
@@ -2,7 +2,8 @@
   "button-labels": {
     "previous": "Previous",
     "next": "Next",
-    "finish": "Finish"
+    "finish": "Finish",
+    "start": "Start"
   },
   "mouse-descriptions": {
     "altitude": "The altitude is displayed at the top left corner of the screen. Right click and drag to go closer or further away.",
@@ -63,7 +64,11 @@
         "task-label-example": "This is a task!",
         "task-label-complete": "This is a completed task!"
       },
-      "lets-go": "Let's dive right in!"
+      "lets-go": "Let's dive right in!",
+      "other-profile-warning": {
+        "title": "Warning",
+        "description": "You are not using the Default profile. Some tour steps may not work as expected. If you encounter issues, please restart OpenSpace using the Default profile."
+      }
     },
     "navigation": {
       "intro": {

--- a/src/components/PropertyOwner/VisiblityCheckbox.tsx
+++ b/src/components/PropertyOwner/VisiblityCheckbox.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 export function PropertyOwnerVisibilityCheckbox({ uri, label }: Props) {
-  const { isVisible, setVisiblity } = usePropertyOwnerVisibility(uri);
+  const { isVisible, setVisibility } = usePropertyOwnerVisibility(uri);
 
   // This is the value that is shown in the checkbox, it is not necessarily the same as
   // the isVisible value, since the checkbox can be in a transition state
@@ -28,7 +28,7 @@ export function PropertyOwnerVisibilityCheckbox({ uri, label }: Props) {
   }
 
   function updateValue(shouldBeEnabled: boolean, isImmediate: boolean) {
-    setVisiblity(shouldBeEnabled, isImmediate);
+    setVisibility(shouldBeEnabled, isImmediate);
     setChecked(shouldBeEnabled);
   }
 

--- a/src/hooks/propertyOwner.ts
+++ b/src/hooks/propertyOwner.ts
@@ -75,7 +75,7 @@ export function usePropertyOwnerVisibility(uri: Uri) {
 
   const isVisible = checkVisiblity(enabledPropertyValue, fadePropertyValue);
 
-  function setVisiblity(shouldShow: boolean, isImmediate: boolean = false) {
+  function setVisibility(shouldShow: boolean, isImmediate: boolean = false) {
     const fadeTime = isImmediate ? 0 : undefined;
     if (!isFadeable) {
       setEnabledProperty(shouldShow);
@@ -88,6 +88,6 @@ export function usePropertyOwnerVisibility(uri: Uri) {
 
   return {
     isVisible,
-    setVisiblity
+    setVisibility
   };
 }

--- a/src/panels/GettingStartedPanel/GettingStartedPanel.tsx
+++ b/src/panels/GettingStartedPanel/GettingStartedPanel.tsx
@@ -75,21 +75,25 @@ export function GettingStartedPanel() {
   }
 
   function setupGettingStartedTour(): void {
-    luaApi?.navigation.jumpTo('Earth');
-    luaApi?.action.triggerAction('os.earth_standard_illumination');
-    luaApi?.setPropertyValue(
-      'Scene.Earth.Renderable.Layers.ColorLayers.*.Enabled',
-      false
-    );
-    setVisibleEsriViirsCombo(true);
-    luaApi?.time.setPause(false);
-    luaApi?.time.interpolateDeltaTime(1);
-    luaApi?.fadeIn('Scene.EarthTrail.Renderable');
-    luaApi?.setPropertyValue(
-      'Scene.Mars.Renderable.Layers.ColorLayers.CTX_Mosaic_Sweden.Enabled',
-      false
-    );
-    luaApi?.fadeOut('Scene.Constellations.Renderable');
+    luaApi?.setPropertyValueSingle('RenderEngine.BlackoutFactor', 0.0, 1.0);
+    setTimeout(() => {
+      luaApi?.navigation.jumpTo('Earth');
+      luaApi?.action.triggerAction('os.earth_standard_illumination');
+      luaApi?.setPropertyValue(
+        'Scene.Earth.Renderable.Layers.ColorLayers.*.Enabled',
+        false
+      );
+      setVisibleEsriViirsCombo(true);
+      luaApi?.time.setPause(false);
+      luaApi?.time.interpolateDeltaTime(1);
+      luaApi?.fadeIn('Scene.EarthTrail.Renderable');
+      luaApi?.setPropertyValue(
+        'Scene.Mars.Renderable.Layers.ColorLayers.CTX_Mosaic_Sweden.Enabled',
+        false
+      );
+      luaApi?.fadeOut('Scene.Constellations.Renderable');
+      luaApi?.setPropertyValueSingle('RenderEngine.BlackoutFactor', 1.0, 1.0);
+    }, 1000);
   }
 
   return (
@@ -115,7 +119,8 @@ export function GettingStartedPanel() {
           <Button
             onClick={onClickNext}
             variant={'filled'}
-            rightSection={!isLastStep && <ArrowRightIcon />}
+            rightSection={!isLastStep && !isLastIntroductionStep && <ArrowRightIcon />}
+            color={!isLastStep && !isLastIntroductionStep ? 'blue' : 'green'}
           >
             {nextButtonLabel()}
           </Button>

--- a/src/panels/GettingStartedPanel/GettingStartedPanel.tsx
+++ b/src/panels/GettingStartedPanel/GettingStartedPanel.tsx
@@ -2,9 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Group, Stack } from '@mantine/core';
 
-import { useOpenSpaceApi } from '@/api/hooks';
 import { Layout } from '@/components/Layout/Layout';
-import { usePropertyOwnerVisibility } from '@/hooks/propertyOwner';
 import { ArrowLeftIcon, ArrowRightIcon } from '@/icons/icons';
 import { useWindowLayoutProvider } from '@/windowmanagement/WindowLayout/hooks';
 
@@ -22,10 +20,6 @@ export function GettingStartedPanel() {
   const navigationSteps = useNavigationSteps();
   const timeSteps = useTimeSteps();
   const contentSteps = useContentSteps();
-  const luaApi = useOpenSpaceApi();
-  const { setVisibility: setVisibleEsriViirsCombo } = usePropertyOwnerVisibility(
-    'Scene.Earth.Renderable.Layers.ColorLayers.ESRI_VIIRS_Combo'
-  );
 
   const { t } = useTranslation('panel-gettingstartedtour');
 
@@ -63,37 +57,12 @@ export function GettingStartedPanel() {
     if (isLastStep) {
       closeWindow('gettingStartedTour');
     } else {
-      if (isLastIntroductionStep) {
-        setupGettingStartedTour();
-      }
       setStep(step + 1);
     }
   }
 
   function onClickPrev() {
     setStep(step - 1);
-  }
-
-  function setupGettingStartedTour(): void {
-    luaApi?.setPropertyValueSingle('RenderEngine.BlackoutFactor', 0.0, 1.0);
-    setTimeout(() => {
-      luaApi?.navigation.jumpTo('Earth');
-      luaApi?.action.triggerAction('os.earth_standard_illumination');
-      luaApi?.setPropertyValue(
-        'Scene.Earth.Renderable.Layers.ColorLayers.*.Enabled',
-        false
-      );
-      setVisibleEsriViirsCombo(true);
-      luaApi?.time.setPause(false);
-      luaApi?.time.interpolateDeltaTime(1);
-      luaApi?.fadeIn('Scene.EarthTrail.Renderable');
-      luaApi?.setPropertyValue(
-        'Scene.Mars.Renderable.Layers.ColorLayers.CTX_Mosaic_Sweden.Enabled',
-        false
-      );
-      luaApi?.fadeOut('Scene.Constellations.Renderable');
-      luaApi?.setPropertyValueSingle('RenderEngine.BlackoutFactor', 1.0, 1.0);
-    }, 1000);
   }
 
   return (

--- a/src/panels/GettingStartedPanel/Steps/IntroductionSteps.tsx
+++ b/src/panels/GettingStartedPanel/Steps/IntroductionSteps.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Image, List, Stack, Text } from '@mantine/core';
+import { Alert, Image, List, Stack, Text } from '@mantine/core';
+
+import { useAppSelector } from '@/redux/hooks';
 
 import { TaskCheckbox } from '../Tasks/Components/TaskCheckbox';
 
 export function useIntroductionSteps(): React.ReactNode[] {
+  const profileName = useAppSelector((state) => state.profile.name);
   const { t } = useTranslation('panel-gettingstartedtour', {
     keyPrefix: 'steps.introduction'
   });
+  const isDefaultProfile = profileName === 'Default';
 
   return [
     <Stack align={'center'}>
@@ -36,6 +40,15 @@ export function useIntroductionSteps(): React.ReactNode[] {
     </>,
     <>
       <Text>{t('lets-go')}</Text>
+      {!isDefaultProfile && (
+        <Alert
+          variant={'light'}
+          color={'orange'}
+          title={t('other-profile-warning.title')}
+        >
+          <Text>{t('other-profile-warning.description')}</Text>
+        </Alert>
+      )}
     </>
   ];
 }

--- a/src/panels/GettingStartedPanel/Tasks/Components/ClearSkyButton.tsx
+++ b/src/panels/GettingStartedPanel/Tasks/Components/ClearSkyButton.tsx
@@ -8,7 +8,7 @@ import { IconSize } from '@/types/enums';
 
 export function ClearSkyButton() {
   const luaApi = useOpenSpaceApi();
-  const { setVisiblity: setVisibleBlueMarble } = usePropertyOwnerVisibility(
+  const { setVisibility: setVisibleBlueMarble } = usePropertyOwnerVisibility(
     'Scene.Earth.Renderable.Layers.ColorLayers.Blue_Marble'
   );
 


### PR DESCRIPTION
Starts the getting started tour with expected values (based on steps) so that no step is completed before user interaction. Also adds a warning if the user is not on the Default profile

closes https://github.com/OpenSpace/OpenSpace/issues/3402