### PR TITLE
Hide the rcdock drag initiator component in the headless openspace rendering view

### DIFF
--- a/src/windowmanagement/WindowLayout/WindowLayout.css
+++ b/src/windowmanagement/WindowLayout/WindowLayout.css
@@ -13,6 +13,12 @@ body {
     &.dock-panel-dropping .dock-bar {
       opacity: 0;
     }
+
+    /* Hide the bar at the top of the window that otherwise is used to move windows
+       around. We don't want it for the transparent headless view */
+    .drag-initiator {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
closes OpenSpace/OpenSpace#3706