### PR TITLE
Add tooltips to truncated text

### DIFF
--- a/public/locales/en/panel-geolocation.json
+++ b/public/locales/en/panel-geolocation.json
@@ -25,8 +25,7 @@
     "node-name-placeholder": "Custom Coordinate {{anchor}} ({{latitude}}, {{longitude}}, {{altitude}}km)"
   },
   "added-custom-nodes": {
-    "empty-nodes": "No added nodes",
-    "remove-node-aria-label": "Remove node"
+    "empty-nodes": "No added nodes"
   },
   "add-scene-graph-node-button": {
     "label": "Add focus"

--- a/public/locales/en/panel-geolocation.json
+++ b/public/locales/en/panel-geolocation.json
@@ -25,7 +25,8 @@
     "node-name-placeholder": "Custom Coordinate {{anchor}} ({{latitude}}, {{longitude}}, {{altitude}}km)"
   },
   "added-custom-nodes": {
-    "empty-nodes": "No added nodes"
+    "empty-nodes": "No added nodes",
+    "remove-node-aria-label": "Remove node"
   },
   "add-scene-graph-node-button": {
     "label": "Add focus"

--- a/src/components/ThreePartHeader/ThreePartHeader.tsx
+++ b/src/components/ThreePartHeader/ThreePartHeader.tsx
@@ -1,4 +1,6 @@
-import { Flex, Group, Text } from '@mantine/core';
+import { Flex, Group } from '@mantine/core';
+
+import { TruncatedText } from '../TruncatedText/TruncatedText';
 
 interface Props {
   title: React.ReactNode;
@@ -8,20 +10,10 @@ interface Props {
 
 export function ThreePartHeader({ title, leftSection, rightSection }: Props) {
   return (
-    <Group justify={'space-between'} gap={'xs'} wrap={'nowrap'}>
+    <Group justify={'left'} gap={'xs'} wrap={'nowrap'}>
       {leftSection}
-      <Flex flex={1}>
-        {typeof title === 'string' ? (
-          <Text
-            ta={'left'}
-            style={{ textWrap: 'pretty', overflowWrap: 'anywhere' }}
-            lineClamp={1}
-          >
-            {title}
-          </Text>
-        ) : (
-          title
-        )}
+      <Flex flex={1} miw={0}>
+        {typeof title === 'string' ? <TruncatedText>{title}</TruncatedText> : title}
       </Flex>
       {rightSection}
     </Group>

--- a/src/components/ThreePartHeader/ThreePartHeader.tsx
+++ b/src/components/ThreePartHeader/ThreePartHeader.tsx
@@ -13,7 +13,17 @@ export function ThreePartHeader({ title, leftSection, rightSection }: Props) {
     <Group justify={'left'} gap={'xs'} wrap={'nowrap'}>
       {leftSection}
       <Flex flex={1} miw={0}>
-        {typeof title === 'string' ? <TruncatedText>{title}</TruncatedText> : title}
+        {typeof title === 'string' ? (
+          <TruncatedText
+            ta={'left'}
+            style={{ textWrap: 'pretty', overflowWrap: 'anywhere' }}
+            lineClamp={1}
+          >
+            {title}
+          </TruncatedText>
+        ) : (
+          title
+        )}
       </Flex>
       {rightSection}
     </Group>

--- a/src/components/TruncatedText/TruncatedText.tsx
+++ b/src/components/TruncatedText/TruncatedText.tsx
@@ -1,0 +1,32 @@
+import { PropsWithChildren } from 'react';
+import { Text, TextProps, Tooltip, TooltipProps } from '@mantine/core';
+import { useResizeObserver } from '@mantine/hooks';
+
+interface Props extends PropsWithChildren, TextProps {
+  tooltipProps?: TooltipProps;
+}
+
+/**
+ * Component that displays text with truncation and a tooltip. The tooltip shows the full
+ * text when hovered over, and is only shown if the text is truncated.
+ */
+export function TruncatedText({ tooltipProps, children, ...rest }: Props) {
+  // This will case the component to rerender when the text is resized, which is necessary
+  // to determine if the text is truncated or not.
+  const [ref] = useResizeObserver();
+
+  const showTooltip: boolean =
+    ref.current && ref.current.scrollWidth > ref.current.clientWidth;
+
+  return (
+    <Tooltip
+      label={children}
+      {...tooltipProps}
+      style={{ display: showTooltip ? 'block' : 'none' }}
+    >
+      <Text truncate {...rest} ref={ref}>
+        {children}
+      </Text>
+    </Tooltip>
+  );
+}

--- a/src/components/TruncatedText/TruncatedText.tsx
+++ b/src/components/TruncatedText/TruncatedText.tsx
@@ -16,7 +16,9 @@ export function TruncatedText({ tooltipProps, children, ...rest }: Props) {
   const [ref] = useResizeObserver();
 
   const showTooltip: boolean =
-    ref.current && ref.current.scrollWidth > ref.current.clientWidth;
+    ref.current &&
+    (ref.current.scrollWidth > ref.current.clientWidth ||
+      ref.current.scrollHeight > ref.current.clientHeight);
 
   return (
     <Tooltip

--- a/src/components/TruncatedText/TruncatedText.tsx
+++ b/src/components/TruncatedText/TruncatedText.tsx
@@ -21,11 +21,7 @@ export function TruncatedText({ tooltipProps, children, ...rest }: Props) {
       ref.current.scrollHeight > ref.current.clientHeight);
 
   return (
-    <Tooltip
-      label={children}
-      {...tooltipProps}
-      style={{ display: showTooltip ? 'block' : 'none' }}
-    >
+    <Tooltip label={children} {...tooltipProps} display={showTooltip ? 'block' : 'none'}>
       <Text truncate {...rest} ref={ref}>
         {children}
       </Text>

--- a/src/panels/GeoLocationPanel/AddedCustomNodes.tsx
+++ b/src/panels/GeoLocationPanel/AddedCustomNodes.tsx
@@ -1,18 +1,13 @@
 import { useTranslation } from 'react-i18next';
-import { ActionIcon, Group, Text } from '@mantine/core';
+import { Text } from '@mantine/core';
 
-import { MinusIcon } from '@/icons/icons';
 import { SceneGraphNodeHeader } from '@/panels/Scene/SceneGraphNode/SceneGraphNodeHeader';
 import { useAppSelector } from '@/redux/hooks';
 import { GeoLocationGroupKey } from '@/util/keys';
 import { identifierFromUri, sgnUri } from '@/util/propertyTreeHelpers';
-import { useAnchorNode } from '@/util/propertyTreeHooks';
-import { useRemoveSceneGraphNodeModal } from '@/util/useRemoveSceneGraphNode';
 
 export function AddedCustomNodes() {
   const groups = useAppSelector((state) => state.groups.groups);
-  const anchor = useAnchorNode();
-  const removeSceneGraphNode = useRemoveSceneGraphNodeModal();
 
   const geoLocationOwners = groups[GeoLocationGroupKey]?.propertyOwners.map((uri) =>
     identifierFromUri(uri)
@@ -27,23 +22,11 @@ export function AddedCustomNodes() {
     return <Text>{t('empty-nodes')}</Text>;
   }
 
+  // @TODO: This should be replaced with a custom header component for geo locations
   return (
     <>
       {addedCustomNodes.map((identifier) => (
-        <Group key={identifier} wrap={'nowrap'} grow preventGrowOverflow={false}>
-          <ActionIcon
-            variant={'light'}
-            size={'sm'}
-            color={'red'}
-            flex={0}
-            onClick={() => removeSceneGraphNode(identifier, identifier)}
-            aria-label={`${t('remove-node-aria-label')}: ${identifier}`}
-            disabled={anchor?.identifier === identifier}
-          >
-            <MinusIcon />
-          </ActionIcon>
-          <SceneGraphNodeHeader uri={sgnUri(identifier)} />
-        </Group>
+        <SceneGraphNodeHeader key={identifier} uri={sgnUri(identifier)} />
       ))}
     </>
   );

--- a/src/panels/GeoLocationPanel/AddedCustomNodes.tsx
+++ b/src/panels/GeoLocationPanel/AddedCustomNodes.tsx
@@ -1,13 +1,18 @@
 import { useTranslation } from 'react-i18next';
-import { Text } from '@mantine/core';
+import { ActionIcon, Group, Text } from '@mantine/core';
 
+import { MinusIcon } from '@/icons/icons';
 import { SceneGraphNodeHeader } from '@/panels/Scene/SceneGraphNode/SceneGraphNodeHeader';
 import { useAppSelector } from '@/redux/hooks';
 import { GeoLocationGroupKey } from '@/util/keys';
 import { identifierFromUri, sgnUri } from '@/util/propertyTreeHelpers';
+import { useAnchorNode } from '@/util/propertyTreeHooks';
+import { useRemoveSceneGraphNodeModal } from '@/util/useRemoveSceneGraphNode';
 
 export function AddedCustomNodes() {
   const groups = useAppSelector((state) => state.groups.groups);
+  const anchor = useAnchorNode();
+  const removeSceneGraphNode = useRemoveSceneGraphNodeModal();
 
   const geoLocationOwners = groups[GeoLocationGroupKey]?.propertyOwners.map((uri) =>
     identifierFromUri(uri)
@@ -22,11 +27,29 @@ export function AddedCustomNodes() {
     return <Text>{t('empty-nodes')}</Text>;
   }
 
-  // @TODO: This should be replaced with a custom header component for geo locations
   return (
     <>
       {addedCustomNodes.map((identifier) => (
-        <SceneGraphNodeHeader key={identifier} uri={sgnUri(identifier)} />
+        <Group
+          key={identifier}
+          gap={'xs'}
+          wrap={'nowrap'}
+          grow
+          preventGrowOverflow={false}
+        >
+          <ActionIcon
+            variant={'light'}
+            size={'sm'}
+            color={'red'}
+            flex={0}
+            onClick={() => removeSceneGraphNode(identifier, identifier)}
+            aria-label={`${t('remove-node-aria-label')}: ${identifier}`}
+            disabled={anchor?.identifier === identifier}
+          >
+            <MinusIcon />
+          </ActionIcon>
+          <SceneGraphNodeHeader uri={sgnUri(identifier)} />
+        </Group>
       ))}
     </>
   );

--- a/src/panels/KeybindsPanel/ListEntry.tsx
+++ b/src/panels/KeybindsPanel/ListEntry.tsx
@@ -1,5 +1,6 @@
-import { Button, Text } from '@mantine/core';
+import { Button } from '@mantine/core';
 
+import { TruncatedText } from '@/components/TruncatedText/TruncatedText';
 import { KeybindInfoType } from '@/types/types';
 
 import { KeybindButtons } from './KeybindButtons';
@@ -22,7 +23,7 @@ export function KeybindListEntry({ keybind, onClick, isSelected }: Props) {
       }
       justify={'space-between'}
     >
-      <Text truncate>{keybind.name}</Text>
+      <TruncatedText>{keybind.name}</TruncatedText>
     </Button>
   );
 }

--- a/src/panels/LogPanel/ScriptLogEntry.tsx
+++ b/src/panels/LogPanel/ScriptLogEntry.tsx
@@ -6,6 +6,7 @@ import { useOpenSpaceApi } from '@/api/hooks';
 import { CopyToClipboardButton } from '@/components/CopyToClipboardButton/CopyToClipboardButton';
 import { BoolInput } from '@/components/Input/BoolInput';
 import { RerunScriptIcon } from '@/icons/icons';
+import styles from '@/theme/global.module.css';
 
 interface Props {
   script: string;
@@ -32,6 +33,7 @@ export function ScriptLogEntry({ script, index, isSelected, onToggleSelection }:
       />
       <Code color={'dark.7'} w={'100%'}>
         <Text
+          className={styles.selectable}
           truncate={expanded ? undefined : 'end'}
           onClick={() => setExpanded(!expanded)}
           style={{ cursor: 'pointer', wordBreak: 'break-all' }}

--- a/src/panels/NavigationPanel/AnchorAimView/AnchorAimListEntry.tsx
+++ b/src/panels/NavigationPanel/AnchorAimView/AnchorAimListEntry.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
-import { ActionIcon, Group, MantineStyleProps, Text, Tooltip } from '@mantine/core';
+import { ActionIcon, Group, MantineStyleProps, Tooltip } from '@mantine/core';
 
+import { TruncatedText } from '@/components/TruncatedText/TruncatedText';
 import { AnchorIcon, TelescopeIcon } from '@/icons/icons';
 import { Identifier, PropertyOwner } from '@/types/types';
 
@@ -34,9 +35,9 @@ export function AnchorAimListEntry({
 
   return (
     <Group gap={'xs'} key={node.identifier} {...styleProps}>
-      <Text flex={1} truncate pl={'xs'}>
+      <TruncatedText flex={1} pl={'xs'}>
         {node.name}
-      </Text>
+      </TruncatedText>
       <Tooltip label={t('anchor-tooltip')} openDelay={600}>
         <ActionIcon
           aria-label={`${t('anchor-aria-label')}: ${node.name}`}

--- a/src/panels/NavigationPanel/AnchorAimView/AnchorAimView.tsx
+++ b/src/panels/NavigationPanel/AnchorAimView/AnchorAimView.tsx
@@ -3,6 +3,7 @@ import { Button, Divider, Group, Kbd, Space, Text, Title, Tooltip } from '@manti
 
 import { FilterList } from '@/components/FilterList/FilterList';
 import { InfoBox } from '@/components/InfoBox/InfoBox';
+import { TruncatedText } from '@/components/TruncatedText/TruncatedText';
 import { useProperty } from '@/hooks/properties';
 import { useSubscribeToEngineMode } from '@/hooks/topicSubscriptions';
 import { AnchorIcon, TelescopeIcon } from '@/icons/icons';
@@ -111,7 +112,7 @@ export function AnchorAimView({
             disabled={isInFlight}
             miw={100}
           >
-            <Text truncate>{anchorNode?.name}</Text>
+            <TruncatedText>{anchorNode?.name}</TruncatedText>
           </Button>
         </Tooltip>
 
@@ -128,7 +129,7 @@ export function AnchorAimView({
             miw={100}
           >
             {aimNode ? (
-              <Text truncate>{aimNode.name}</Text>
+              <TruncatedText>{aimNode.name}</TruncatedText>
             ) : (
               <Text c={'dimmed'}>{t('no-aim')}</Text>
             )}

--- a/src/panels/NavigationPanel/FocusView/FocusEntry.tsx
+++ b/src/panels/NavigationPanel/FocusView/FocusEntry.tsx
@@ -1,6 +1,7 @@
-import { Button, Group, MantineStyleProps, Text } from '@mantine/core';
+import { Button, Group, MantineStyleProps } from '@mantine/core';
 
 import { NodeNavigationButton } from '@/components/NodeNavigationButton/NodeNavigationButton';
+import { TruncatedText } from '@/components/TruncatedText/TruncatedText';
 import { FocusIcon } from '@/icons/icons';
 import { IconSize, NavigationType } from '@/types/enums';
 import { Identifier, PropertyOwner } from '@/types/types';
@@ -39,7 +40,7 @@ export function FocusEntry({
         disabled={disableFocus}
         miw={70}
       >
-        <Text truncate>{entry.name}</Text>
+        <TruncatedText>{entry.name}</TruncatedText>
       </Button>
 
       <Group gap={'xs'}>

--- a/src/panels/NavigationPanel/MenuButton/NavigationPanelMenuButtonContent.tsx
+++ b/src/panels/NavigationPanel/MenuButton/NavigationPanelMenuButtonContent.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Group, Stack, Text } from '@mantine/core';
 
+import { TruncatedText } from '@/components/TruncatedText/TruncatedText';
 import { AnchorIcon, FocusIcon, TelescopeIcon } from '@/icons/icons';
 import { IconSize } from '@/types/enums';
 import { useAimNode, useAnchorNode } from '@/util/propertyTreeHooks';
@@ -20,7 +21,7 @@ export function NavigationPanelMenuButtonContent() {
         <Group gap={5} align={'center'}>
           <AnchorIcon size={IconSize.md} />
           <Stack gap={0} maw={130} ta={'start'}>
-            <Text truncate>{anchorNode?.name}</Text>
+            <TruncatedText>{anchorNode?.name}</TruncatedText>
             <Text fw={500} size={'xs'} c={'dimmed'}>
               {t('anchor')}
             </Text>
@@ -29,7 +30,7 @@ export function NavigationPanelMenuButtonContent() {
         <Group gap={5}>
           <TelescopeIcon size={IconSize.md} />
           <Stack gap={0} maw={130} ta={'start'}>
-            <Text truncate>{aimNode?.name}</Text>
+            <TruncatedText>{aimNode?.name}</TruncatedText>
             <Text fw={500} size={'xs'} c={'dimmed'}>
               {t('aim')}
             </Text>
@@ -44,7 +45,7 @@ export function NavigationPanelMenuButtonContent() {
     <Group>
       <FocusIcon size={IconSize.lg} />
       <Stack gap={0} maw={130} ta={'start'}>
-        <Text truncate>{anchorNode?.name}</Text>
+        <TruncatedText>{anchorNode?.name}</TruncatedText>
         <Text fw={500} size={'xs'} c={'dimmed'}>
           {t('focus')}
         </Text>

--- a/src/panels/NavigationPanel/RemainingFlightTimeIndicator.tsx
+++ b/src/panels/NavigationPanel/RemainingFlightTimeIndicator.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Group, Text } from '@mantine/core';
 
+import { TruncatedText } from '@/components/TruncatedText/TruncatedText';
 import { usePropertyOwner } from '@/hooks/propertyOwner';
 import { useSubscribeToCameraPath } from '@/hooks/topicSubscriptions';
 import { AirplaneIcon } from '@/icons/icons';
@@ -27,9 +28,7 @@ export function RemainingFlightTimeIndicator({ compact = true }: Props) {
     <Group className={styles.blinking} wrap={'nowrap'} gap={'xs'} p={'xs'}>
       <AirplaneIcon style={{ flexShrink: 0 }} size={IconSize.lg} />
       {compact ? (
-        <Text truncate maw={130}>
-          {pathTargetNodeName}
-        </Text>
+        <TruncatedText maw={130}>{pathTargetNodeName}</TruncatedText>
       ) : (
         <Text ta={'center'}>{t('flying-to', { target: pathTargetNodeName })}</Text>
       )}

--- a/src/panels/Scene/SceneGraphNode/SceneGraphNodeHeader.tsx
+++ b/src/panels/Scene/SceneGraphNode/SceneGraphNodeHeader.tsx
@@ -1,9 +1,10 @@
 import { useTranslation } from 'react-i18next';
-import { Button, Group, Text, Tooltip } from '@mantine/core';
+import { Button, Group, Tooltip } from '@mantine/core';
 
 import { NodeNavigationButton } from '@/components/NodeNavigationButton/NodeNavigationButton';
 import { PropertyOwnerVisibilityCheckbox } from '@/components/PropertyOwner/VisiblityCheckbox';
 import { ThreePartHeader } from '@/components/ThreePartHeader/ThreePartHeader';
+import { TruncatedText } from '@/components/TruncatedText/TruncatedText';
 import { usePropertyOwner } from '@/hooks/propertyOwner';
 import { useIsSgnFocusable } from '@/hooks/sceneGraphNodes/hooks';
 import { ClockOffIcon } from '@/icons/icons';
@@ -49,13 +50,13 @@ export function SceneGraphNodeHeader({ uri, onClick, label }: Props) {
       justify={'start'}
       flex={1}
     >
-      <Text
+      <TruncatedText
         ta={'left'}
         style={{ textWrap: 'pretty', overflowWrap: 'anywhere', wordBreak: 'break-word' }}
         lineClamp={3}
       >
         {name}
-      </Text>
+      </TruncatedText>
     </Button>
   );
 

--- a/src/panels/SettingsPanel/SettingsSearchListItem.tsx
+++ b/src/panels/SettingsPanel/SettingsSearchListItem.tsx
@@ -1,7 +1,8 @@
-import { Stack, Text } from '@mantine/core';
+import { Stack } from '@mantine/core';
 
 import { Property } from '@/components/Property/Property';
 import { PropertyOwner } from '@/components/PropertyOwner/PropertyOwner';
+import { TruncatedText } from '@/components/TruncatedText/TruncatedText';
 import { removeLastWordFromUri } from '@/util/propertyTreeHelpers';
 
 import { SearchItemType } from './util';
@@ -19,9 +20,7 @@ export function SettingsSearchListItem({ type, uri }: Props) {
   const isSubowner = type == SearchItemType.SubPropertyOwner;
   return (
     <Stack gap={0}>
-      <Text truncate c={'dimmed'}>
-        {removeLastWordFromUri(uri)}
-      </Text>
+      <TruncatedText c={'dimmed'}>{removeLastWordFromUri(uri)}</TruncatedText>
       {isSubowner ? <PropertyOwner uri={uri} /> : <Property uri={uri} />}
     </Stack>
   );

--- a/src/panels/SkyBrowserPanel/ImageList/ImageCard.tsx
+++ b/src/panels/SkyBrowserPanel/ImageList/ImageCard.tsx
@@ -1,6 +1,7 @@
-import { Card, Group, Text, Tooltip } from '@mantine/core';
+import { Card, Group, Tooltip } from '@mantine/core';
 
 import { useOpenSpaceApi } from '@/api/hooks';
+import { TruncatedText } from '@/components/TruncatedText/TruncatedText';
 import { PlusIcon } from '@/icons/icons';
 import { useAppSelector } from '@/redux/hooks';
 
@@ -38,7 +39,7 @@ export function ImageCard({ image }: Props) {
       <Card.Section p={'xs'}>
         <Group wrap={'nowrap'}>
           <Tooltip label={image.name}>
-            <Text truncate={'end'}>{image.name}</Text>
+            <TruncatedText>{image.name}</TruncatedText>
           </Tooltip>
           <ImageInfoPopover image={image} />
         </Group>

--- a/src/theme/mantineTheme.ts
+++ b/src/theme/mantineTheme.ts
@@ -107,7 +107,8 @@ export const theme = createTheme({
           hover: true,
           focus: true,
           touch: true
-        }
+        },
+        style: { overflowWrap: 'anywhere' }
       }
     }),
     Divider: Divider.extend({


### PR DESCRIPTION
Adds a new component that automatically adds a tooltip to any truncated texts. 
Closes OpenSpace/OpenSpace#3750

The tooltip is displayed only when the text is truncated

Works for both one-line truncation and texts with line clamp:
<img width="45%"  alt="image" src="https://github.com/user-attachments/assets/b23ad2dc-cc58-427d-81de-c3a92cb1d558" /> <img width="45%" alt="image" src="https://github.com/user-attachments/assets/980d834c-44a1-43b5-9014-52571cc8edb6" />

This is particularly for added geo locations, that have very long names: 
<img width="380" height="735" alt="image" src="https://github.com/user-attachments/assets/11da633d-b3c5-4679-a26c-57b853154229" />
