### PR TITLE
Add fixed min width to time panel menu button

### DIFF
--- a/src/panels/TimePanel/MenuButton/TimePanelMenuButtonContent.tsx
+++ b/src/panels/TimePanel/MenuButton/TimePanelMenuButtonContent.tsx
@@ -48,7 +48,7 @@ export function TimePanelMenuButtonContent() {
   }
 
   return (
-    <Stack gap={0} align={'flex-start'}>
+    <Stack gap={0} align={'flex-start'} miw={270}>
       {isReady ? (
         <>
           <Text size={'lg'}>{isValidDate ? timeLabel : timeString}</Text>


### PR DESCRIPTION
Prevents the rest of the UI from "jumping around". This was brought up both during our dev review, and I saw a comment about how to prevent it in the support Slack. 

PR since I want to hear what the rest of you think before merging. This adds space so the time button stays fixed in size for years up to 5 digits, but after more digits, it starts "jumping" again (thinking that this is probably fine since it's a rare use case). 

https://github.com/user-attachments/assets/513a29ac-12df-48ea-bfce-e875ce5cb0a8

