### PR TITLE
Add translation for menu items title

### DIFF
--- a/public/locales/en/menu.json
+++ b/public/locales/en/menu.json
@@ -74,6 +74,28 @@
   "windows-menu": {
     "title": "Windows"
   },
+  "panels": {
+    "scene": "Scene",
+    "settings": "Settings",
+    "navigation": "Navigation",
+    "timePanel": "Time Panel",
+    "sessionRecording": "Session Recording",
+    "geoLocation": "Geo Location",
+    "screenSpaceRenderables": "Screenspace Renderables",
+    "exoplanets": "Exoplanets",
+    "userPanels": "User Panels",
+    "actions": "Actions",
+    "skyBrowser": "SkyBrowser",
+    "mission": "Mission",
+    "flightControl": "Flight Control",
+    "keybindingsLayout": "Keybinds",
+    "nightSky": "Night Sky",
+    "gettingStartedTour": "Getting Started Tour",
+    "scriptLogPanel": "Script Log",
+    "globeImageryBrowserPanel": "Globe Imagery Browser",
+    "assetsPanel": "Assets",
+    "devPanel": "Dev Panel"
+  },
   "error-load-toolbar-layout": {
     "title": "Error loading JSON file",
     "messages": {

--- a/src/panels/Menu/Toolbar/Toolbar.tsx
+++ b/src/panels/Menu/Toolbar/Toolbar.tsx
@@ -36,7 +36,7 @@ export function Toolbar() {
                 item.renderMenuButton(item.componentID)
               ) : (
                 <ToolbarMenuButton id={item.componentID}>
-                  {item.renderIcon ? item.renderIcon(IconSize.lg) : item.title}
+                  {item.renderIcon ? item.renderIcon(IconSize.lg) : item.title()}
                 </ToolbarMenuButton>
               )}
             </Box>

--- a/src/panels/Menu/Toolbar/ToolbarMenuButton.tsx
+++ b/src/panels/Menu/Toolbar/ToolbarMenuButton.tsx
@@ -26,7 +26,7 @@ export function ToolbarMenuButton({ id, children, ...props }: Props) {
       closeWindow(item.componentID);
     } else {
       addWindow(item.content, {
-        title: item.title,
+        title: item.title(),
         position: item.preferredPosition,
         id: item.componentID,
         floatPosition: item.floatPosition
@@ -49,7 +49,7 @@ export function ToolbarMenuButton({ id, children, ...props }: Props) {
       onContextMenu={onRightClick}
       size={'xl'}
       variant={'menubar'}
-      aria-label={item.title}
+      aria-label={item.title()}
       style={{
         borderBottom: item?.isOpen
           ? 'var(--openspace-border-active)'

--- a/src/panels/Menu/TopMenuBar/Menus/FileMenu.tsx
+++ b/src/panels/Menu/TopMenuBar/Menus/FileMenu.tsx
@@ -5,7 +5,7 @@ import { modals } from '@mantine/modals';
 import { useOpenSpaceApi } from '@/api/hooks';
 import { LoadingBlocks } from '@/components/LoadingBlocks/LoadingBlocks';
 import { useProperty } from '@/hooks/properties';
-import { ConsoleIcon, DummyIcon, ExitAppIcon } from '@/icons/icons';
+import { ConsoleIcon, ExitAppIcon, InformationCircleOutlineIcon } from '@/icons/icons';
 import { useAppSelector } from '@/redux/hooks';
 import styles from '@/theme/global.module.css';
 
@@ -42,7 +42,7 @@ export function FileMenu() {
   }
 
   return (
-    <TopBarMenuWrapper targetTitle={'File'} closeOnItemClick={false}>
+    <TopBarMenuWrapper targetTitle={t('title')} closeOnItemClick={false}>
       {!profile.initalized ? (
         <LoadingBlocks n={1} />
       ) : (
@@ -52,7 +52,7 @@ export function FileMenu() {
           </Menu.Label>
           <Menu.Sub position={'right-start'} withinPortal={false}>
             <Menu.Sub.Target>
-              <Menu.Sub.Item leftSection={<DummyIcon color={'transparent'} />}>
+              <Menu.Sub.Item leftSection={<InformationCircleOutlineIcon />}>
                 {t('about.label')}
               </Menu.Sub.Item>
             </Menu.Sub.Target>

--- a/src/panels/Menu/TopMenuBar/Menus/HelpMenu.tsx
+++ b/src/panels/Menu/TopMenuBar/Menus/HelpMenu.tsx
@@ -41,7 +41,7 @@ export function HelpMenu() {
       <About opened={showAbout} close={close} />
       <QRCode opened={showQRCode} close={closeQRCode} />
 
-      <TopBarMenuWrapper targetTitle={'Help'}>
+      <TopBarMenuWrapper targetTitle={t('title')}>
         <Menu.Item
           component={'a'}
           href={
@@ -65,14 +65,14 @@ export function HelpMenu() {
             leftSection={item.renderIcon?.(IconSize.xs)}
             onClick={() =>
               addWindow(item.content, {
-                title: item.title,
+                title: item.title(),
                 position: item.preferredPosition,
                 id: item.componentID,
                 floatPosition: item.floatPosition
               })
             }
           >
-            {item.title}
+            {item.title()}
           </Menu.Item>
         ))}
 

--- a/src/panels/Menu/TopMenuBar/Menus/ViewMenu.tsx
+++ b/src/panels/Menu/TopMenuBar/Menus/ViewMenu.tsx
@@ -109,7 +109,7 @@ export function ViewMenu() {
                     )
                   }
                 >
-                  {item.title}
+                  {item.title()}
                 </Menu.Item>
               );
             }}

--- a/src/panels/Menu/TopMenuBar/Menus/WindowMenuEntries.tsx
+++ b/src/panels/Menu/TopMenuBar/Menus/WindowMenuEntries.tsx
@@ -20,7 +20,7 @@ export function WindowMenuEntries({ items }: Props) {
             leftSection={item.renderIcon?.(IconSize.xs)}
             onClick={() =>
               addWindow(item.content, {
-                title: item.title,
+                title: item.title(),
                 position: item.preferredPosition,
                 id: item.componentID,
                 floatPosition: item.floatPosition
@@ -34,7 +34,7 @@ export function WindowMenuEntries({ items }: Props) {
             }}
             flex={1}
           >
-            {item.title}
+            {item.title()}
           </Menu.Item>
           <Box w={IconSize.md}>
             {item.isOpen && (

--- a/src/panels/Menu/hooks.ts
+++ b/src/panels/Menu/hooks.ts
@@ -80,7 +80,7 @@ export function useMenuItemsByGroup<Included extends MenuItemGroup = MenuItemGro
     // order defined by the `menuItemsData`
     for (const group of groups) {
       if (group !== 'Ungrouped') {
-        menuItemsByGroup[group].sort((a, b) => a.title.localeCompare(b.title));
+        menuItemsByGroup[group].sort((a, b) => a.title().localeCompare(b.title()));
       }
     }
 
@@ -104,7 +104,7 @@ function useShowWindowOnStart(shouldShow: boolean, menuItem: MenuItem) {
       // Open the window if it is visible
       addWindow(menuItem.content, {
         id: menuItem.componentID,
-        title: menuItem.title,
+        title: menuItem.title(),
         position: menuItem.preferredPosition,
         floatPosition: menuItem.floatPosition
       });
@@ -178,7 +178,7 @@ export function useStoredLayout() {
         const item = menuItemsData[layoutItem.id];
         addWindow(item.content, {
           id: item.componentID,
-          title: item.title,
+          title: item.title(),
           position: item.preferredPosition,
           floatPosition: item.floatPosition
         });

--- a/src/redux/local/localMiddleware.ts
+++ b/src/redux/local/localMiddleware.ts
@@ -186,7 +186,7 @@ export const addLocalListener = (startListening: AppStartListening) => {
       const menuItemsConfig = Object.values(menuItemsData).map((item) => ({
         id: item.componentID,
         visible: item.defaultVisible,
-        name: item.title,
+        name: item.title(),
         isOpen: false
       }));
 

--- a/src/windowmanagement/data/MenuItems.tsx
+++ b/src/windowmanagement/data/MenuItems.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import i18next from 'i18next';
 
 import {
   BrowserIcon,
@@ -55,7 +56,7 @@ import {
 } from './LazyLoads';
 
 export interface MenuItem {
-  title: string; // Title of the rc-dock tab
+  title: () => string; // Title of the rc-dock tab
   componentID: string; // Unqiue ID to identify this component among the rc-dock tabs
   content: React.ReactNode; // Content to render inside the rc-dock tab
   renderMenuButton?: (id: string) => React.JSX.Element; // Custom menu button to render
@@ -69,7 +70,7 @@ export interface MenuItem {
 
 export const menuItemsData: Record<string, MenuItem> = {
   scene: {
-    title: 'Scene',
+    title: () => i18next.t('menu:panels.scene'),
     componentID: 'scene',
     content: <Scene />,
     renderMenuButton: (id) => (
@@ -83,7 +84,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Ungrouped'
   },
   settings: {
-    title: 'Settings',
+    title: () => i18next.t('menu:panels.settings'),
     componentID: 'settings',
     content: <SettingsPanel />,
     renderMenuButton: (id) => (
@@ -97,7 +98,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Ungrouped'
   },
   navigation: {
-    title: 'Navigation',
+    title: () => i18next.t('menu:panels.navigation'),
     componentID: 'navigation',
     content: <NavigationPanel />,
     renderMenuButton: (id) => <NavigationPanelMenuButton id={id} />,
@@ -108,7 +109,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Ungrouped'
   },
   timePanel: {
-    title: 'Time Panel',
+    title: () => i18next.t('menu:panels.timePanel'),
     componentID: 'timePanel',
     content: <TimePanel />,
     renderMenuButton: (id) => (
@@ -123,7 +124,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Ungrouped'
   },
   sessionRecording: {
-    title: 'Session Recording',
+    title: () => i18next.t('menu:panels.sessionRecording'),
     componentID: 'sessionRecording',
     content: <SessionRecordingPanel />,
     renderMenuButton: (id) => <SessionRecordingMenuButton id={id} />,
@@ -133,7 +134,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Other'
   },
   geoLocation: {
-    title: 'Geo Location',
+    title: () => i18next.t('menu:panels.geoLocation'),
     componentID: 'geoLocation',
     content: <GeoLocationPanel />,
     renderIcon: (size) => <LocationPinIcon size={size} />,
@@ -142,7 +143,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Content'
   },
   screenSpaceRenderables: {
-    title: 'Screenspace Renderables',
+    title: () => i18next.t('menu:panels.screenSpaceRenderables'),
     componentID: 'screenSpaceRenderables',
     content: <ScreenSpaceRenderablePanel />,
     renderIcon: (size) => <InsertPhotoIcon size={size} />,
@@ -151,7 +152,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Ungrouped'
   },
   exoplanets: {
-    title: 'Exoplanets',
+    title: () => i18next.t('menu:panels.exoplanets'),
     componentID: 'exoplanets',
     content: <ExoplanetsPanel />,
     renderIcon: (size) => <ExoplanetIcon size={size} />,
@@ -160,7 +161,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Content'
   },
   userPanels: {
-    title: 'User Panels',
+    title: () => i18next.t('menu:panels.userPanels'),
     componentID: 'userPanels',
     content: <UserPanelsPanel />,
     renderIcon: (size) => <BrowserIcon size={size} />,
@@ -169,7 +170,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Other'
   },
   actions: {
-    title: 'Actions',
+    title: () => i18next.t('menu:panels.actions'),
     componentID: 'actions',
     content: <ActionsPanel />,
     renderIcon: (size) => <DashboardIcon size={size} />,
@@ -178,7 +179,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Ungrouped'
   },
   skyBrowser: {
-    title: 'SkyBrowser',
+    title: () => i18next.t('menu:panels.skyBrowser'),
     componentID: 'skyBrowser',
     content: <SkyBrowserPanel />,
     renderIcon: (size) => <TelescopeIcon size={size} />,
@@ -187,7 +188,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Content'
   },
   mission: {
-    title: 'Mission',
+    title: () => i18next.t('menu:panels.mission'),
     componentID: 'mission',
     content: <MissionsPanel />,
     renderIcon: (size) => <RocketLaunchIcon size={size} />,
@@ -196,7 +197,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Content'
   },
   flightControl: {
-    title: 'Flight Control',
+    title: () => i18next.t('menu:panels.flightControl'),
     componentID: 'flightControl',
     content: <FlightControlPanel />,
     renderIcon: (size) => <ExpandArrowsIcon size={size} />,
@@ -205,7 +206,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Other'
   },
   keybindingsLayout: {
-    title: 'Keybinds',
+    title: () => i18next.t('menu:panels.keybindingsLayout'),
     componentID: 'keybindingsLayout',
     content: <KeybindsPanel />,
     renderIcon: (size) => <KeyboardIcon size={size} />,
@@ -215,7 +216,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Help'
   },
   nightSky: {
-    title: 'Night Sky',
+    title: () => i18next.t('menu:panels.nightSky'),
     componentID: 'nightSky',
     content: <NightSkyPanel />,
     renderIcon: (size) => <NightSkyIcon size={size} />,
@@ -224,7 +225,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Content'
   },
   gettingStartedTour: {
-    title: 'Getting Started Tour',
+    title: () => i18next.t('menu:panels.gettingStartedTour'),
     componentID: 'gettingStartedTour',
     content: <GettingStartedPanel />,
     renderIcon: (size) => <RouteIcon size={size} style={{ transform: 'scale(-1)' }} />,
@@ -234,7 +235,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Help'
   },
   scriptLogPanel: {
-    title: 'Script Log',
+    title: () => i18next.t('menu:panels.scriptLogPanel'),
     componentID: 'scriptLogPanel',
     content: <ScriptLogPanel />,
     renderIcon: (size) => <ScriptLogIcon size={size} />,
@@ -243,7 +244,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Other'
   },
   globeImageryBrowserPanel: {
-    title: 'Globe Imagery Browser',
+    title: () => i18next.t('menu:panels.globeImageryBrowserPanel'),
     componentID: 'globeImageryBrowserPanel',
     content: <GlobeImageryBrowserPanel />,
     renderIcon: (size) => <GlobeIcon size={size} />,
@@ -252,7 +253,7 @@ export const menuItemsData: Record<string, MenuItem> = {
     group: 'Content'
   },
   assetsPanel: {
-    title: 'Assets',
+    title: () => i18next.t('menu:panels.assetsPanel'),
     componentID: 'assetsPanel',
     content: <AssetsPanel />,
     renderIcon: (size) => <OpenFolderIcon size={size} />,
@@ -265,7 +266,7 @@ export const menuItemsData: Record<string, MenuItem> = {
 if (import.meta.env.DEV) {
   // Add an extra panel for dev-specific content
   menuItemsData.devPanel = {
-    title: 'Dev Panel',
+    title: () => i18next.t('menu:panels.devPanel'),
     componentID: 'devPanel',
     content: <DevPanel />,
     renderIcon: (size) => <DevIcon size={size} />,


### PR DESCRIPTION
closes https://github.com/OpenSpace/OpenSpace/issues/4003

Use translation titles for File and Help menu. 
Add info icon to File -> About instead of empty icon slot