### PR TITLE
Pop out scene graph nodes to the right instead of floating

### DIFF
--- a/src/panels/Scene/SceneGraphNode/SceneGraphNodeMoreMenu.tsx
+++ b/src/panels/Scene/SceneGraphNode/SceneGraphNodeMoreMenu.tsx
@@ -41,7 +41,7 @@ export function SceneGraphNodeMoreMenu({ uri }: Props) {
     addWindow(<SceneGraphNodeView uri={uri} />, {
       id: 'sgn-' + uri,
       title: name,
-      position: 'float'
+      position: 'right'
     });
   }
 


### PR DESCRIPTION
Before 

https://github.com/user-attachments/assets/e63be185-605e-4653-9f69-ed676b2939c0

After

https://github.com/user-attachments/assets/43aa01d0-c946-4715-9e6b-5c4ed594422b

