### PR TITLE
Change the default height in the panel to 10 km

### DIFF
--- a/src/panels/GeoLocationPanel/GeoLocationPanel.tsx
+++ b/src/panels/GeoLocationPanel/GeoLocationPanel.tsx
@@ -22,7 +22,7 @@ export function GeoLocationPanel() {
   const [coordinates, setCoordinates] = useState<GeoCoordinates>({
     lat: 0,
     long: 0,
-    alt: 0
+    alt: 10
   });
   const [customName, setCustomName] = useState('');
   const [mouseMarker, setMouseMarker] = useState<MouseMarkerPosition>(undefined);


### PR DESCRIPTION
Having it at the default of 0 and flying to a location frequently causes the camera to be below the ground.  10km will give us good margins on Earth to everything, but is otherwise arbitrary