### PR TITLE
Do not display the Flyto/JumpTo/Frame buttons in the kebab menu for SceneGraphNodes that are not focussable

### DIFF
--- a/src/panels/Scene/SceneGraphNode/SceneGraphNodeMoreMenu.tsx
+++ b/src/panels/Scene/SceneGraphNode/SceneGraphNodeMoreMenu.tsx
@@ -63,8 +63,9 @@ export function SceneGraphNodeMoreMenu({ uri }: Props) {
         >
           {t('pop-out')}
         </Button>
-        {isFocusable && <Divider m={'xs'} />}
         {isFocusable && (
+        <>
+          <Divider m={'xs'} />}
           <Stack gap={'xs'}>
             <Group gap={'xs'}>
               <NodeNavigationButton
@@ -86,6 +87,7 @@ export function SceneGraphNodeMoreMenu({ uri }: Props) {
               />
             </Group>
           </Stack>
+          </>
         )}
         <Divider m={'xs'} />
         <Group gap={'xs'}>

--- a/src/panels/Scene/SceneGraphNode/SceneGraphNodeMoreMenu.tsx
+++ b/src/panels/Scene/SceneGraphNode/SceneGraphNodeMoreMenu.tsx
@@ -63,7 +63,7 @@ export function SceneGraphNodeMoreMenu({ uri }: Props) {
         >
           {t('pop-out')}
         </Button>
-        <Divider m={'xs'} />
+        {isFocusable && <Divider m={'xs'} />}
         {isFocusable && (
           <Stack gap={'xs'}>
             <Group gap={'xs'}>

--- a/src/panels/Scene/SceneGraphNode/SceneGraphNodeMoreMenu.tsx
+++ b/src/panels/Scene/SceneGraphNode/SceneGraphNodeMoreMenu.tsx
@@ -5,6 +5,7 @@ import CopyUriButton from '@/components/CopyUriButton/CopyUriButton';
 import { InfoBox } from '@/components/InfoBox/InfoBox';
 import { NodeNavigationButton } from '@/components/NodeNavigationButton/NodeNavigationButton';
 import { usePropertyOwner } from '@/hooks/propertyOwner';
+import { useIsSgnFocusable } from '@/hooks/sceneGraphNodes/hooks';
 import { DeleteIcon, OpenWindowIcon, VerticalDotsIcon } from '@/icons/icons';
 import { IconSize, NavigationType } from '@/types/enums';
 import { Uri } from '@/types/types';
@@ -28,6 +29,7 @@ export function SceneGraphNodeMoreMenu({ uri }: Props) {
   const propertyOwner = usePropertyOwner(uri);
   const anchorNode = useAnchorNode();
   const confirmRemoveSgn = useRemoveSceneGraphNodeModal();
+  const isFocusable = useIsSgnFocusable(uri);
 
   const { addWindow } = useWindowLayoutProvider();
 
@@ -62,27 +64,29 @@ export function SceneGraphNodeMoreMenu({ uri }: Props) {
           {t('pop-out')}
         </Button>
         <Divider m={'xs'} />
-        <Stack gap={'xs'}>
-          <Group gap={'xs'}>
-            <NodeNavigationButton
-              type={NavigationType.Fly}
-              identifier={propertyOwner.identifier}
-              showLabel
-            />
-            <NodeNavigationButton
-              type={NavigationType.Jump}
-              identifier={propertyOwner.identifier}
-              showLabel
-            />
-          </Group>
-          <Group gap={'xs'}>
-            <NodeNavigationButton
-              type={NavigationType.Frame}
-              identifier={propertyOwner.identifier}
-              showLabel
-            />
-          </Group>
-        </Stack>
+        {isFocusable && (
+          <Stack gap={'xs'}>
+            <Group gap={'xs'}>
+              <NodeNavigationButton
+                type={NavigationType.Fly}
+                identifier={propertyOwner.identifier}
+                showLabel
+              />
+              <NodeNavigationButton
+                type={NavigationType.Jump}
+                identifier={propertyOwner.identifier}
+                showLabel
+              />
+            </Group>
+            <Group gap={'xs'}>
+              <NodeNavigationButton
+                type={NavigationType.Frame}
+                identifier={propertyOwner.identifier}
+                showLabel
+              />
+            </Group>
+          </Stack>
+        )}
         <Divider m={'xs'} />
         <Group gap={'xs'}>
           <Button


### PR DESCRIPTION
The focus button in the menu for non-focussable objects was hidden, but it was still possible to break things by opening the Kebab menu and select the navigation buttons there. This PR doesn't add these buttons if the scene graph node is marked as non-focussable.

Before:
<img width="439" height="720" alt="image" src="https://github.com/user-attachments/assets/91c5f0ee-0785-4b98-b3c5-e6bcfc92ed7e" />

After:
<img width="388" height="719" alt="image" src="https://github.com/user-attachments/assets/51008ad4-f9d0-4485-b695-42a36c8e953a" />
